### PR TITLE
add cce resources and data_sources

### DIFF
--- a/docs/data-sources/cce_cluster.md
+++ b/docs/data-sources/cce_cluster.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud\_cce\_cluster
+
+Provides details about all clusters and obtains certificate for accessing cluster information.
+
+## Example Usage
+
+```hcl
+variable "cluster_name" { }
+
+data "sbercloud_cce_cluster" "cluster" {
+  name   = var.cluster_name
+  status = "Available"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the cce clusters. If omitted, the provider-level region will be used.
+
+* `name` -  (Optional, String)The Name of the cluster resource.
+ 
+* `id` - (Optional, String) The ID of container cluster.
+
+* `status` - (Optional, String) The state of the cluster.
+
+* `cluster_type` - (Optional, String) Type of the cluster. Possible values: VirtualMachine, BareMetal.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `billingMode` - Charging mode of the cluster.
+
+* `description` - Cluster description.
+
+* `name` - The name of the cluster in string format.
+  
+* `flavor_id` - The cluster specification in string format.
+
+* `cluster_version` - The version of cluster in string format.
+
+* `container_network_cidr` - The container network segment.
+
+* `container_network_type` - The container network type: overlay_l2 , underlay_ipvlan or vpc-router.
+  
+* `subnet_id` - The ID of the subnet used to create the node.
+
+* `highway_subnet_id` - The ID of the high speed network used to create bare metal nodes.
+
+**endpoints**
+
+* `internal` - The address accessed within the user's subnet.
+
+* `external` - Public network access address.
+
+* `certificate_clusters/name` - The cluster name.
+
+* `certificate_clusters/server` - The server IP address.
+
+* `certificate_clusters/certificate_authority_data` - The certificate data.
+
+* `certificate_users/name` - The user name.
+
+* `certificate_users/client_certificate_data` - The client certificate data.
+
+* `certificate_users/client_key_data` - The client key data.
+
+* `kube_config_raw` - Raw Kubernetes config to be used by kubectl and other compatible tools.

--- a/docs/data-sources/cce_node.md
+++ b/docs/data-sources/cce_node.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud\_cce\_node
+
+To get the specified node in a cluster.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" { }
+variable "node_name" { }
+
+data "sbercloud_cce_node" "node" {
+  cluster_id = var.cluster_id
+  name       = var.node_name
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the cce nodes. If omitted, the provider-level region will be used.
+ 
+* `Cluster_id` - (Required, String) The id of container cluster.
+
+* `name` - (Optional, String) Name of the node.
+
+* `node_id` - (Optional, String) The id of the node.
+
+* `status` - (Optional, String) The state of the node.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `flavor_id` - The flavor id to be used. 
+
+* `availability_zone` - Available partitions where the node is located. 
+
+* `key_pair` - Key pair name when logging in to select the key pair mode.
+
+* `billing_mode` - Node's billing mode: The value is 0 (on demand).
+
+* `charge_mode` - Bandwidth billing type.
+
+* `bandwidth_size` - Bandwidth (Mbit/s), in the range of [1, 2000].
+
+* `extendparam` - 	Extended parameters. 
+    
+* `node_count` - The number of nodes in batch creation.
+
+* `eip_ids` - List of existing elastic IP IDs.
+ 
+* `server_id` - The node's virtual machine ID in ECS.
+
+* `public_ip` - Elastic IP parameters of the node.
+
+* `private_ip` - Private IP of the node
+
+* `ip_type` - Elastic IP address type.
+
+* `share_type` - The bandwidth sharing type.
+
+NOTE:
+This parameter is mandatory when share_type is set to PER and is optional when share_type is set to WHOLE with an ID specified.
+
+Enumerated values: PER (indicates exclusive bandwidth) and WHOLE (indicates sharing)
+
+
+**root_volumes**
+
+* `disk_size` - Disk size in GB.
+
+* `volumetype` - Disk type.
+
+**data_volumes**
+
+* `disk_size` - Disk size in GB.
+
+* `volumetype` - Disk type.

--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -5,7 +5,6 @@ subcategory: "Image Management Service (IMS)"
 # sbercloud\_images\_image
 
 Use this data source to get the ID of an available Sbercloud image.
-This is an alternative to `sbercloud_images_image`
 
 ## Example Usage
 

--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -5,7 +5,6 @@ subcategory: "Virtual Private Cloud (VPC)"
 # sbercloud\_networking\_port
 
 Use this data source to get the ID of an available Sbercloud port.
-This is an alternative to `sbercloud_networking_port_v2`
 
 ## Example Usage
 

--- a/docs/data-sources/networking_secgroup.md
+++ b/docs/data-sources/networking_secgroup.md
@@ -5,7 +5,6 @@ subcategory: "Virtual Private Cloud (VPC)"
 # sbercloud\_networking\_secgroup
 
 Use this data source to get the ID of an available Sbercloud security group.
-This is an alternative to `sbercloud_networking_secgroup_v2`
 
 ## Example Usage
 

--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -1,0 +1,182 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud\_cce\_cluster
+
+Provides a CCE cluster resource.
+
+## Basic Usage
+
+```hcl
+resource "sbercloud_vpc" "myvpc" {
+  name = "vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "sbercloud_vpc_subnet" "mysubnet" {
+  name          = "subnet"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.13.59"
+  secondary_dns = "8.8.8.8"
+  vpc_id        = sbercloud_vpc.myvpc.id
+}
+
+resource "sbercloud_cce_cluster" "cluster" {
+  name                   = "cluster"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.myvpc.id
+  subnet_id              = sbercloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+}
+```
+
+## Cluster With Eip
+
+```hcl
+resource "sbercloud_vpc" "myvpc" {
+  name = "vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "sbercloud_vpc_subnet" "mysubnet" {
+  name          = "subnet"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.13.59"
+  secondary_dns = "8.8.8.8"
+  vpc_id        = sbercloud_vpc.myvpc.id
+}
+
+resource "sbercloud_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "sbercloud_cce_cluster" "cluster" {
+  name                   = "cluster"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.myvpc.id
+  subnet_id              = sbercloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = sbercloud_vpc_eip.myeip.address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cce cluster resource. If omitted, the provider-level region will be used. Changing this creates a new cce cluster resource.
+
+* `name` - (Required, String, ForceNew) Cluster name. Changing this parameter will create a new cluster resource.
+
+* `flavor_id` - (Required, String, ForceNew) Cluster specifications. Changing this parameter will create a new cluster resource. Possible values:
+
+	* `cce.s1.small` - small-scale single cluster (up to 50 nodes).
+	* `cce.s1.medium` - medium-scale single cluster (up to 200 nodes).
+	* `cce.s1.large` - large-scale single cluster (up to 1000 nodes).
+	* `cce.s2.small` - small-scale HA cluster (up to 50 nodes).
+	* `cce.s2.medium` - medium-scale HA cluster (up to 200 nodes).
+	* `cce.s2.large` - large-scale HA cluster (up to 1000 nodes).
+	* `cce.t1.small` - small-scale single physical machine cluster (up to 10 nodes).
+	* `cce.t1.medium` - medium-scale single physical machine cluster (up to 100 nodes).
+	* `cce.t1.large` - large-scale single physical machine cluster (up to 500 nodes).
+	* `cce.t2.small` - small-scale HA physical machine cluster (up to 10 nodes).
+	* `cce.t2.medium` - medium-scale HA physical machine cluster (up to 100 nodes).
+	* `cce.t2.large` - large-scale HA physical machine cluster (up to 500 nodes).
+
+* `cluster_version` - (Optional, String, ForceNew) For the cluster version, defaults to the latest supported version. To learn which cluster
+versions are available, choose Dashboard > Buy Cluster on the CCE console. Changing this parameter will create a new cluster resource.
+
+* `cluster_type` - (Optional, String, ForceNew) Cluster Type, possible values are VirtualMachine, BareMetal and ARM64. Defaults to *VirtualMachine*.
+  Changing this parameter will create a new cluster resource.
+
+* `description` - (Optional, String) The Cluster description.
+
+* `billing_mode` - (Optional, Int, ForceNew) Charging mode of the cluster, which is 0 (on demand). Changing this parameter will create a new cluster resource.
+
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new cluster resource.
+
+* `vpc_id` - (Required, String, ForceNew) The ID of the VPC used to create the node. Changing this parameter will create a new cluster resource.
+
+* `subnet_id` - (Required, String, ForceNew) The ID of the subnet used to create the node  which should be configured with a *DNS address*.
+  Changing this parameter will create a new cluster resource.
+
+* `highway_subnet_id` - (Optional, String, ForceNew) The ID of the high speed network used to create bare metal nodes. Changing this parameter will create a new cluster resource.
+
+* `container_network_type` - (Required, String, ForceNew) Container network parameters. Possible values:
+
+	* `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS)
+	* `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
+	* `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
+
+* `container_network_cidr` - (Optional, String, ForceNew) Container network segment. Changing this parameter will create a new cluster resource.
+
+* `authentication_mode` - (Optional, String, ForceNew) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
+    Changing this parameter will create a new cluster resource.
+
+* `authenticating_proxy_ca` - (Optional, String, ForceNew) CA root certificate provided in the authenticating_proxy mode. The CA root certificate
+	is encoded to the Base64 format. Changing this parameter will create a new cluster resource.
+
+* `multi_az` - (Optional, Bool, ForceNew) Enable multiple AZs for the cluster, only when using HA flavors. Changing this parameter will create a new cluster resource.
+
+* `eip` - (Optional, String, ForceNew) EIP address of the cluster. Changing this parameter will create a new cluster resource.
+
+* `kube_proxy_mode` - (Optional, String, ForceNew) Service forwarding mode. Two modes are available:
+
+  - iptables: Traditional kube-proxy uses iptables rules to implement service load balancing. In this mode, too many iptables rules will be generated when many services are deployed. In addition, non-incremental updates will cause a latency and even obvious performance issues in the case of heavy service traffic.
+  - ipvs: Optimized kube-proxy mode with higher throughput and faster speed. This mode supports incremental updates and can keep connections uninterrupted during service updates. It is suitable for large-sized clusters.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the cce cluster. Changing this creates a new cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+  * `id` -  Id of the cluster resource.
+
+  * `status` -  Cluster status information.
+
+  * `certificate_clusters/name` - The cluster name.
+
+  * `certificate_clusters/server` - The server IP address.
+
+  * `certificate_clusters/certificate_authority_data` - The certificate data.
+
+  * `certificate_users/name` - The user name.
+
+  * `certificate_users/client_certificate_data` - The client certificate data.
+
+  * `certificate_users/client_key_data` - The client key data.
+
+  * `security_group_id` - Security group ID of the cluster.
+
+  * `kube_config_raw` - Raw Kubernetes config to be used by kubectl and other compatible tools.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 30 minute.
+- `delete` - Default is 30 minute.
+
+## Import
+
+ Cluster can be imported using the cluster id, e.g.
+ ```
+ $ terraform import sbercloud_cce_cluster.cluster_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d  
+```
+

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -1,0 +1,198 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud\_cce\_node
+Add a node to a container cluster.
+
+## Basic Usage
+
+```hcl
+
+data "sbercloud_availability_zones" "myaz" {}
+
+resource "sbercloud_compute_keypair" "mykp" {
+  name       = "mykp"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "sbercloud_cce_cluster" "mycluster" {
+  name                   = "mycluster"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.myvpc.id
+  subnet_id              = sbercloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+}
+
+resource "sbercloud_cce_node" "node" {
+  cluster_id        = sbercloud_cce_cluster.mycluster.id
+  name              = "node"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.sbercloud_availability_zones.myaz.names[0]
+  key_pair          = sbercloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+}
+```
+
+## Node with Eip
+
+```hcl
+resource "sbercloud_cce_node" "mynode" {
+  cluster_id        = sbercloud_cce_cluster.mycluster.id
+  name              = "mynode"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.sbercloud_availability_zones.myaz.names[0]
+  key_pair          = sbercloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+
+  // Assign EIP
+  iptype                = "5_bgp"
+  bandwidth_charge_mode = "traffic"
+  sharetype             = "PER"
+  bandwidth_size        = 100
+}
+```
+
+## Node with Existing Eip
+
+```hcl
+resource "sbercloud_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "sbercloud_cce_node" "mynode" {
+  cluster_id        = sbercloud_cce_cluster.mycluster.id
+  name              = "mynode"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.sbercloud_availability_zones.myaz.names[0]
+  key_pair          = sbercloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+
+  // Assign existing EIP
+  eip_id = sbercloud_vpc_eip.myeip.id
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cce node resource. If omitted, the provider-level region will be used. Changing this creates a new cce node resource.
+
+* `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
+
+* `name` - (Optional, String) Node Name.
+
+* `flavor_id` - (Required, String, ForceNew) Specifies the flavor id. Changing this parameter will create a new resource.
+
+* `availability_zone` - (Required, String, ForceNew) specify the name of the available partition (AZ). Changing this parameter will create a new resource.
+
+* `os` - (Optional, String, ForceNew) Operating System of the node. Changing this parameter will create a new resource.
+    - For VM nodes, clusters of v1.13 and later support *EulerOS 2.5* and *CentOS 7.6*.
+    - For BMS nodes purchased in the yearly/monthly billing mode, only *EulerOS 2.3* is supported.
+
+* `key_pair` - (Optional, String, ForceNew) Key pair name when logging in to select the key pair mode. This parameter and `password` are alternative.
+    Changing this parameter will create a new resource.
+
+* `password` - (Optional, String, ForceNew) root password when logging in to select the password mode. This parameter must be salted and alternative to `key_pair`.
+    Changing this parameter will create a new resource.
+
+* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
+
+* `eip_id` - (Optional, String, ForceNew) The ID of the EIP. Changing this parameter will create a new resource.
+
+
+-> **Note:** If the eip_id parameter is configured, you do not need to configure the bandwidth parameters:
+  `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
+
+* `iptype` - (Optional, String) Elastic IP type. Changing this parameter will create a new resource.
+
+* `bandwidth_charge_mode` - (Optional, String) Bandwidth billing type. Changing this parameter will create a new resource.
+
+* `sharetype` - (Optional, String) Bandwidth sharing type. Changing this parameter will create a new resource.
+
+* `bandwidth_size` - (Optional, Int) Bandwidth size. Changing this parameter will create a new resource.
+
+* `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create. Changing this parameter will create a new cluster resource.
+
+* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
+    Changing this parameter will create a new resource.
+
+* `postinstall` - (Optional, String, ForceNew) Script required after installation. The input value can be a Base64 encoded string or not.
+   Changing this parameter will create a new resource.
+
+* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
+
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+
+  * `size` - (Required, Int) Disk size in GB.
+  * `volumetype` - (Required, String) Disk type.
+  * `extend_param` - (Optional, String) Disk expansion parameters.
+
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+
+  * `size` - (Required, Int) Disk size in GB.
+  * `volumetype` - (Required, String) Disk type.
+  * `extend_param` - (Optional, String) Disk expansion parameters.
+
+* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
+
+  * `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-),
+    underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+  * `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters,
+    digits, hyphens (-), underscores (_), and periods (.).
+  * `effect` - (Required, String) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+ * `status` -  Node status information.
+
+ * `server_id` - ID of the ECS instance associated with the node.
+
+ * `private_ip` - Private IP of the CCE node.
+
+ * `public_ip` - Public IP of the CCE node.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 20 minute.
+- `delete` - Default is 20 minute.
+

--- a/docs/resources/compute_eip_associate.md
+++ b/docs/resources/compute_eip_associate.md
@@ -4,8 +4,7 @@ subcategory: "Elastic Cloud Server (ECS)"
 
 # sbercloud\_compute\_eip\_associate
 
-Associate an EIP to an instance. This is an alternative to
-`sbercloud_compute_floatingip_associate_v2`.
+Associate an EIP to an instance.
 
 ## Example Usage
 

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -5,7 +5,6 @@ subcategory: "Elastic Cloud Server (ECS)"
 # sbercloud\_compute\_instance
 
 Manages a ECS VM instance resource within Sbercloud.
-This is an alternative to `sbercloud_compute_instance_v2`
 
 ## Example Usage
 

--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -5,7 +5,6 @@ subcategory: "Elastic Cloud Server (ECS)"
 # sbercloud\_compute\_interface\_attach
 
 Attaches a Network Interface to an Instance.
-This is an alternative to `sbercloud_compute_interface_attach_v2`
 
 ## Example Usage
 

--- a/docs/resources/compute_keypair.md
+++ b/docs/resources/compute_keypair.md
@@ -5,7 +5,6 @@ subcategory: "Elastic Cloud Server (ECS)"
 # sbercloud\_compute\_keypair
 
 Manages a keypair resource within Sbercloud.
-This is an alternative to `sbercloud_compute_keypair_v2`
 
 ## Example Usage
 

--- a/docs/resources/compute_servergroup.md
+++ b/docs/resources/compute_servergroup.md
@@ -5,7 +5,6 @@ subcategory: "Elastic Cloud Server (ECS)"
 # sbercloud\_compute\_servergroup
 
 Manages Server Group resource within Sbercloud.
-This is an alternative to `sbercloud_compute_servergroup_v2`
 
 ## Example Usage
 

--- a/docs/resources/compute_volume_attach.md
+++ b/docs/resources/compute_volume_attach.md
@@ -5,7 +5,6 @@ subcategory: "Elastic Cloud Server (ECS)"
 # sbercloud\_compute\_volume\_attach
 
 Attaches a Volume to an Instance.
-This is an alternative to `sbercloud_compute_volume_attach_v2`
 
 ## Example Usage
 

--- a/docs/resources/vpc_bandwidth.md
+++ b/docs/resources/vpc_bandwidth.md
@@ -4,7 +4,7 @@ subcategory: "Elastic IP (EIP)"
 
 # sbercloud\_vpc\_bandwidth
 
-Manages a Shared Bandwidth resource within HuaweiCloud.
+Manages a Shared Bandwidth resource within SberCloud.
 
 ## Example Usage
 

--- a/sbercloud/data_source_sbercloud_cce_cluster_v3_test.go
+++ b/sbercloud/data_source_sbercloud_cce_cluster_v3_test.go
@@ -1,0 +1,56 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEClusterV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find cluster data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("cluster data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCEClusterV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cce_cluster" "test" {
+  name = sbercloud_cce_cluster.test.name
+}
+`, testAccCCEClusterV3_basic(rName))
+}

--- a/sbercloud/data_source_sbercloud_cce_node_v3_test.go
+++ b/sbercloud/data_source_sbercloud_cce_node_v3_test.go
@@ -1,0 +1,55 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCCENodeV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.sbercloud_cce_node.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodeV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find nodes data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Node data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCENodeV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cce_node" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = sbercloud_cce_node.test.name
+}
+`, testAccCCENodeV3_basic(rName))
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -94,6 +94,8 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"sbercloud_availability_zones":  huaweicloud.DataSourceAvailabilityZones(),
+			"sbercloud_cce_cluster":         huaweicloud.DataSourceCCEClusterV3(),
+			"sbercloud_cce_node":            huaweicloud.DataSourceCCENodeV3(),
 			"sbercloud_compute_flavors":     huaweicloud.DataSourceEcsFlavors(),
 			"sbercloud_identity_role_v3":    huaweicloud.DataSourceIdentityRoleV3(),
 			"sbercloud_images_image":        huaweicloud.DataSourceImagesImageV2(),
@@ -107,6 +109,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"sbercloud_cce_cluster":                  huaweicloud.ResourceCCEClusterV3(),
+			"sbercloud_cce_node":                     huaweicloud.ResourceCCENodeV3(),
 			"sbercloud_dns_recordset":                huaweicloud.ResourceDNSRecordSetV2(),
 			"sbercloud_dns_zone":                     huaweicloud.ResourceDNSZoneV2(),
 			"sbercloud_identity_role_assignment_v3":  huaweicloud.ResourceIdentityRoleAssignmentV3(),

--- a/sbercloud/resource_sbercloud_cce_cluster_v3_test.go
+++ b/sbercloud/resource_sbercloud_cce_cluster_v3_test.go
@@ -1,0 +1,250 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+)
+
+func TestAccCCEClusterV3_basic(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "cce.s1.small"),
+					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCCEClusterV3_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "new description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCCEClusterV3_withEip(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_withEip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"eip",
+				},
+			},
+		},
+	})
+}
+
+func TestAccCCEClusterV3_withEpsId(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_withEpsId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", SBC_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*huaweicloud.Config)
+	cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_cce_cluster" {
+			continue
+		}
+
+		_, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Cluster still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*huaweicloud.Config)
+		cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		}
+
+		found, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Cluster not found")
+		}
+
+		*cluster = *found
+
+		return nil
+	}
+}
+
+func testAccCCEClusterV3_Base(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "sbercloud_vpc_subnet" "test" {
+  name          = "%s"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.13.59"
+  secondary_dns = "8.8.8.8"
+  vpc_id        = sbercloud_vpc.test.id
+}
+`, rName, rName)
+}
+
+func testAccCCEClusterV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  description            = "new description"
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_withEip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = sbercloud_vpc_eip.test.address
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_withEpsId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  enterprise_project_id  = "%s"
+}
+
+`, testAccCCEClusterV3_Base(rName), rName, SBC_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/sbercloud/resource_sbercloud_cce_node_v3_test.go
+++ b/sbercloud/resource_sbercloud_cce_node_v3_test.go
@@ -1,0 +1,271 @@
+package sbercloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+)
+
+func TestAccCCENodeV3_basic(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	updateName := rName + "update"
+	resourceName := "sbercloud_cce_node.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_update(rName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_auto_assign_eip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_existing_eip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*huaweicloud.Config)
+	cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+	}
+
+	var clusterId string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "sbercloud_cce_cluster" {
+			clusterId = rs.Primary.ID
+		}
+
+		if rs.Type != "sbercloud_cce_node" {
+			continue
+		}
+
+		_, err := nodes.Get(cceClient, clusterId, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Node still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		c, ok := s.RootModule().Resources[cluster]
+		if !ok {
+			return fmt.Errorf("Cluster not found: %s", c)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		if c.Primary.ID == "" {
+			return fmt.Errorf("Cluster id is not set")
+		}
+
+		config := testAccProvider.Meta().(*huaweicloud.Config)
+		cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		}
+
+		found, err := nodes.Get(cceClient, c.Primary.ID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Node not found")
+		}
+
+		*node = *found
+
+		return nil
+	}
+}
+
+func testAccCCENodeV3_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_availability_zones" "test" {}
+
+resource "sbercloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName, rName)
+}
+
+func testAccCCENodeV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.small.1"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCENodeV3_update(rName, updateName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.small.1"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value_update"
+  }
+}
+`, testAccCCENodeV3_Base(rName), updateName)
+}
+
+func testAccCCENodeV3_auto_assign_eip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.small.1"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  // Assign EIP
+  iptype="5_bgp"
+  bandwidth_charge_mode="traffic"
+  sharetype= "PER"
+  bandwidth_size= 100
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCENodeV3_existing_eip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.small.1"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  // Assign existing EIP
+  eip_id = sbercloud_vpc_eip.test.id
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,11 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
+<<<<<<< HEAD
 # github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c
+=======
+# github.com/huaweicloud/golangsdk v0.0.0-20201222025841-5312fcc13866
+>>>>>>> add cce resources and data_sources
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
 github.com/huaweicloud/golangsdk/openstack
@@ -339,7 +343,11 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/pagination
+<<<<<<< HEAD
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225014516-43556a771b11
+=======
+# github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201223023225-4a6404a47b9a
+>>>>>>> add cce resources and data_sources
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud
 # github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 github.com/jen20/awspolicyequivalence


### PR DESCRIPTION
The following resources and data_sources were added:
data_source_sbercloud_cce_cluster
data_source_sbercloud_cce_node
resource_sbercloud_cce_cluster
resource_sbercloud_cce_node_v3
```bash
make testacc TEST='./sbercloud' TESTARGS='-run TestAccCCE'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccCCE -timeout 360m
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== RUN   TestAccCCEClusterV3_withEip
=== PAUSE TestAccCCEClusterV3_withEip
=== RUN   TestAccCCEClusterV3_withEpsId
=== PAUSE TestAccCCEClusterV3_withEpsId
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3_withEpsId
=== CONT  TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_withEip
=== CONT  TestAccCCEClusterV3_withEpsId
    provider_test.go:49: This environment does not support EPS_ID tests
--- SKIP: TestAccCCEClusterV3_withEpsId (0.01s)
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCEClusterV3_withEip (350.24s)
=== CONT  TestAccCCENodeV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (354.16s)
--- PASS: TestAccCCEClusterV3_basic (405.28s)
--- PASS: TestAccCCENodeV3DataSource_basic (564.32s)
--- PASS: TestAccCCENodeV3_basic (1178.71s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   1178.782s
```