### PR TITLE
add obs resources and data_sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225014516-43556a771b11
+	github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225061100-2c08aa044351
 )

--- a/go.sum
+++ b/go.sum
@@ -119,10 +119,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c h1:Igfi5l8W6r8NGUVOZyaIt1m6JZQqo9Lx5bOXbx53qyE=
-github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225014516-43556a771b11 h1:kj8HeulNoFMmlnvwg57c/pL1+HzPCRFm9U7D77V6mAU=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225014516-43556a771b11/go.mod h1:EjDDKH4Rmcmev+6uTCto+htbsS45Wo4IBfPvvK0Jr4k=
+github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768 h1:v+5rLipFpQ99TnlPneFWn28mw6koeLtXgplfDdpDWag=
+github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225061100-2c08aa044351 h1:UtbwIbXCW5aPZBhCZafj834lOjTbol2OljGa808F77A=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225061100-2c08aa044351/go.mod h1:nRfLGgLZZo9VAyKZyVoMZIGFgF+if+/Wlc3ooxwOuLY=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/common/common.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/common/common.go
@@ -1,0 +1,817 @@
+package common
+
+import (
+	"time"
+)
+
+// Operator 运营商
+type Operator struct {
+	// 运营商的唯一uuid
+	ID string `json:"id"`
+
+	// 运营商的名称
+	Name string `json:"name,omitempty"`
+
+	// 运营商的国际化名称
+	I18nName string `json:"i18n_name,omitempty"`
+
+	// 运营商的简写
+	Sa string `json:"sa"`
+}
+
+type PublicIP struct {
+	// Specifies the ID of the elastic IP address, which uniquely
+	// identifies the elastic IP address.
+	ID string `json:"id"`
+
+	// Specifies the status of the elastic IP address.
+	Status string `json:"status"`
+
+	// Specifies the obtained elastic IP address.
+	PublicIpAddress string `json:"public_ip_address"`
+
+	// Value range: 4, 6, respectively, to create ipv4 and ipv6, when not created ipv4 by default
+	IPVersion int `json:"ip_version"`
+
+	// Specifies the private IP address bound to the elastic IP
+	// address.
+	PrivateIpAddress string `json:"private_ip_address"`
+
+	// Specifies the port ID.
+	PortID string `json:"port_id"`
+
+	// Specifies the time for applying for the elastic IP address.
+	CreateTime string `json:"create_time"`
+
+	// Specifies the bandwidth ID of the elastic IP address.
+	BandwidthID string `json:"bandwidth_id"`
+
+	// Specifies the bandwidth size.
+	BandwidthSize int `json:"bandwidth_size"`
+
+	// Specifies whether the bandwidth is shared or exclusive.
+	BandwidthShareType string `json:"bandwidth_share_type"`
+
+	// Specifies the bandwidth name.
+	BandwidthName string `json:"bandwidth_name"`
+
+	//Operator information
+	Operator Operator `json:"operator"`
+
+	// Specifies the Siteid.
+	SiteID string `json:"site_id"`
+
+	// SiteInfo
+	SiteInfo string `json:"site_info"`
+
+	Region string `json:"region,omitempty"`
+}
+
+// GeoLocation 地理位置
+type GeoLocation struct {
+	// ID 标志
+	ID string `json:"id"`
+
+	// City 城市
+	City string `json:"city,omitempty"`
+
+	// I18nCity 城市的国家化名称
+	I18nCity string `json:"i18n_city,omitempty"`
+
+	// Province 省份
+	Province string `json:"province,omitempty"`
+
+	// I18nProvince 省份的国际化名称
+	I18nProvince string `json:"i18n_province,omitempty"`
+
+	// Area 区域
+	Area string `json:"area,omitempty"`
+
+	// I18nArea 区域国际化名称
+	I18nArea string `json:"i18n_area,omitempty"`
+
+	// Country 国家
+	Country string `json:"country"`
+
+	// I18nCountry 国家的国际化名称
+	I18nCountry string `json:"i18n_country,omitempty"`
+}
+
+// Subnet represents a subnet. See package documentation for a top-level
+// description of what this is.
+type Subnet struct {
+	// Specifies a resource ID in UUID format.
+	ID string `json:"id"`
+
+	// Specifies the subnet name. The value is a string of 1 to 64
+	// characters that can contain letters, digits, underscores (_), and hyphens (-).
+	Name string `json:"name"`
+
+	// Specifies the network segment on which the subnet resides. The
+	// value must be in CIDR format. The value must be within the CIDR block of the VPC. The
+	// subnet mask cannot be greater than 28.
+	Cidr string `json:"cidr"`
+
+	// Specifies the gateway of the subnet. The value must be a valid
+	// IP address. The value must be an IP address in the subnet segment.
+	GatewayIP string `json:"gateway_ip"`
+
+	// Specifies whether the DHCP function is enabled for the subnet.
+	// The value can be true or false. If this parameter is left blank, it is set to true by
+	// default.
+	DhcpEnable bool `json:"dhcp_enable,omitempty"`
+
+	// Specifies the IP address of DNS server 1 on the subnet. The
+	// value must be a valid IP address.
+	PrimaryDNS string `json:"primary_dns,omitempty"`
+
+	// Specifies the IP address of DNS server 2 on the subnet. The
+	// value must be a valid IP address.
+	SecondaryDNS string `json:"secondary_dns,omitempty"`
+
+	// Specifies the DNS server address list of a subnet. This field
+	// is required if you need to use more than two DNS servers. This parameter value is the
+	// superset of both DNS server address 1 and DNS server address 2.
+	DNSList []string `json:"dnsList,omitempty"`
+
+	// Specifies the ID of the VPC to which the subnet belongs.
+	VpcID string `json:"vpc_id"`
+
+	// Specifies the status of the subnet. The value can be ACTIVE,
+	// DOWN, UNKNOWN, or ERROR.
+	Status string `json:"status"`
+
+	// Specifies the network (Native OpenStack API) ID.
+	NeutronNetworkID string `json:"neutron_network_id"`
+
+	// Specifies the subnet (Native OpenStack API) ID.
+	NeutronSubnetID string `json:"neutron_subnet_id"`
+
+	// SiteID
+	SiteID string `json:"site_id,omitempty"`
+
+	//SiteInfo
+	SiteInfo string `json:"site_info,omitempty"`
+}
+
+type VPC struct {
+	// Specifies a resource ID in UUID format.
+	ID string `json:"id"`
+
+	// Specifies the name of the VPC. The name must be unique for a
+	// tenant. The value is a string of no more than 64 characters and can contain digits,
+	// letters, underscores (_), and hyphens (-).
+	Name string `json:"name,omitempty"`
+
+	// Specifies the range of available subnets in the VPC. The value
+	// must be in CIDR format, for example, 192.168.0.0/16. The value ranges from 10.0.0.0/8
+	// to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to
+	// 192.168.255.0/24.
+	Cidr string `json:"cidr,omitempty"`
+
+	// SubnetNum
+	SubnetNum int64 `json:"subnet_num"`
+
+	Mode string `json:"mode,omitempty"`
+}
+
+// SiteAttribute 站点扩展属性
+type SiteAttribute struct {
+	// 站点属性的唯一uuid
+	ID string `json:"id"`
+
+	// 站点相对应的属性的key
+	Key string `json:"site_attr"`
+
+	// 站点相对应属性的value
+	Value string `json:"site_attr_value"`
+}
+
+// SiteBase 站点的基本信息
+type SiteBase struct {
+	// 站点所在的城市
+	City string `json:"city,omitempty"`
+
+	// 城市的国家化名称
+	I18nCity string `json:"i18n_city,omitempty"`
+
+	// 站点所在的省份
+	Province string `json:"province,omitempty"`
+
+	// 省份的国际化名称
+	I18nProvince string `json:"i18n_province,omitempty"`
+
+	// 站点所在的区域
+	Area string `json:"area,omitempty"`
+
+	// 区域国际化名称
+	I18nArea string `json:"i18n_area,omitempty"`
+
+	// 站点所在的国家
+	Country string `json:"country,omitempty"`
+
+	// 国家的国际化名称
+	I18nCountry string `json:"i18n_country,omitempty"`
+
+	Operator *Operator `json:"operator,omitempty"`
+}
+
+// Site 站点信息
+type Site struct {
+	// 站点的唯一uuid
+	ID string `json:"id"`
+
+	// 站点的名称，最好按照一定的规则命名，比如:IEG-国家-区域-省-市-运营商
+	Name string `json:"name"`
+
+	SiteBase
+
+	//站点的状态,
+	Status string `json:"status"`
+}
+
+type Port struct {
+	// Specifies the port ID, which uniquely identifies the port.
+	ID string `json:"id"`
+
+	// Specifies the port name. The value can contain no more than 255
+	// characters. This parameter is left blank by default.
+	Name string `json:"name"`
+
+	// Specifies the ID of the network to which the port belongs. The
+	// network ID must be a real one in the network environment.
+	NetworkID string `json:"network_id"`
+
+	// Specifies the administrative state of the port. The value can
+	// only be?true, and the default value is?true.
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Specifies the port MAC address. The system automatically sets
+	// this parameter, and you are not allowed to configure the parameter value.
+	MacAddress string `json:"mac_address"`
+
+	// Specifies the port IP address. A port supports only one fixed
+	// IP address that cannot be changed.
+	FixedIPs []FixedIp `json:"fixed_ips"`
+
+	// Specifies the ID of the device to which the port belongs. The
+	// system automatically sets this parameter, and you are not allowed to configure or
+	// change the parameter value.
+	DeviceID string `json:"device_id"`
+
+	// Specifies the belonged device, which can be the DHCP server,
+	// router, load balancers, or Nova. The system automatically sets this parameter, and
+	// you are not allowed to configure or change the parameter value.
+	DeviceOwner string `json:"device_owner"`
+
+	// Specifies the status of the port. The value can
+	// be?ACTIVE,?BUILD, or?DOWN.
+	Status string `json:"status"`
+
+	// Specifies the UUID of the security group. This attribute is
+	// extended.
+	SecurityGroups []string `json:"security_groups"`
+
+	// 1. Specifies a set of zero or more allowed address pairs. An
+	// address pair consists of an IP address and MAC address. This attribute is extended.
+	// For details, see parameter?allow_address_pair. 2. The IP address cannot be?0.0.0.0.
+	// 3. Configure an independent security group for the port if a large CIDR block (subnet
+	// mask less than 24) is configured for parameter?allowed_address_pairs.
+	AllowedAddressPairs []AllowedAddressPair `json:"allowed_address_pairs"`
+
+	// Specifies a set of zero or more extra DHCP option pairs. An
+	// option pair consists of an option value and name. This attribute is extended.
+	ExtraDhcpOpts []ExtraDHCPOpt `json:"extra_dhcp_opts"`
+
+	// Specifies the type of the bound vNIC. The value can
+	// be?normal?or?direct. Parameter?normal?indicates software switching.
+	// Parameter?direct?indicates SR-IOV PCIe passthrough, which is not supported.
+	BindingvnicType string `json:"binding:vnic_type"`
+
+	// Default private domain name of the main NIC
+	DnsAssignment []DnsAssignment `json:"dns_assignment"`
+
+	// Default private DNS name of the main NIC
+	DnsName string `json:"dns_name"`
+
+	// site id
+	SiteID string `json:"site_id"`
+}
+
+type FixedIp struct {
+	// Specifies the subnet ID. You cannot change the parameter
+	// value.
+	SubnetId string `json:"subnet_id,omitempty"`
+
+	// Specifies the port IP address. You cannot change the parameter
+	// value.
+	IpAddress string `json:"ip_address,omitempty"`
+}
+
+type DnsAssignment struct {
+	// 功能说明：fqdn
+	Fqdn string `json:"fqdn,omitempty"`
+
+	// 功能说明：hostname
+	HostName string `json:"hostname,omitempty"`
+
+	// 功能说明：ip_address
+	IpAddress string `json:"ip_address,omitempty"`
+}
+
+type ExtraDHCPOpt struct {
+	// 功能说明：Option名称
+	OptName string `json:"opt_name,omitempty"`
+
+	// 功能说明：Option值
+	OptValue string `json:"opt_value,omitempty"`
+}
+
+type AllowedAddressPair struct {
+	// Specifies the IP address. You cannot set it to 0.0.0.0.
+	// Configure an independent security group for the port if a large CIDR block (subnet
+	// mask less than 24) is configured for parameter allowed_address_pairs.
+	IpAddress string `json:"ip_address,omitempty"`
+
+	// Specifies the MAC address.
+	MacAddress string `json:"mac_address,omitempty"`
+}
+
+type Bandwidth struct {
+	// Specifies the bandwidth name. The value is a string of 1 to 64
+	// characters that can contain letters, digits, underscores (_), and hyphens (-).
+	Name string `json:"name"`
+
+	// Specifies the bandwidth size. The value ranges from 1 Mbit/s to
+	// 300 Mbit/s.
+	Size int `json:"size"`
+
+	// Specifies the bandwidth ID, which uniquely identifies the
+	// bandwidth.
+	ID string `json:"id"`
+
+	// Specifies whether the bandwidth is shared or exclusive. The
+	// value can be PER or WHOLE.
+	ShareType string `json:"share_type"`
+
+	// Specifies the elastic IP address of the bandwidth.  The
+	// bandwidth, whose type is set to WHOLE, supports up to 20 elastic IP addresses. The
+	// bandwidth, whose type is set to PER, supports only one elastic IP address.
+	PublicipInfo []PublicIpinfo `json:"publicip_info"`
+
+	// Specifies the tenant ID of the user.
+	TenantId string `json:"tenant_id"`
+
+	// Specifies the bandwidth type.
+	BandwidthType string `json:"bandwidth_type"`
+
+	// Specifies the charging mode (by traffic or by bandwidth).
+	ChargeMode string `json:"charge_mode"`
+
+	// Specifies the status of bandwidth
+	Status string `json:"status"`
+
+	SiteID string `json:"site_id,omitempty"`
+
+	CreateTime time.Time `json:"create_time,omitempty"`
+
+	SiteInfo string `json:"site_info,omitempty"`
+
+	Operator Operator `json:"operator,omitempty"`
+
+	UpdateTime time.Time `json:"update_time,omitempty"`
+}
+
+type PublicIpinfo struct {
+	// Specifies the tenant ID of the user.
+	PublicipId string `json:"publicip_id"`
+
+	// Specifies the elastic IP address.
+	PublicipAddress string `json:"publicip_address"`
+
+	// Specifies the elastic IP version.
+	IPVersion int `json:"ip_version"`
+
+	// Specifies the elastic IP address type. The value can be
+	// 5_telcom, 5_union, or 5_bgp.
+	PublicipType string `json:"publicip_type"`
+}
+
+// Volume contains all the information associated with an OpenStack Volume.
+type Volume struct {
+	// Unique identifier for the volume.
+	ID string `json:"id"`
+	// Current status of the volume.
+	Status string `json:"status"`
+	// Size of the volume in GB.
+	Size int `json:"size"`
+	// AvailabilityZone is which availability zone the volume is in.
+	AvailabilityZone string `json:"availability_zone"`
+	// The date when this volume was created.
+	CreatedAt time.Time `json:"-"`
+	// The date when this volume was last updated
+	UpdatedAt time.Time `json:"-"`
+	// Instances onto which the volume is attached.
+	Attachments []Attachment `json:"attachments"`
+	// Human-readable display name for the volume.
+	Name string `json:"name"`
+	// Human-readable description for the volume.
+	Description string `json:"description"`
+	// The type of volume to create, either SATA or SSD.
+	VolumeType string `json:"volume_type"`
+	// The ID of the snapshot from which the volume was created
+	SnapshotID string `json:"snapshot_id"`
+	// The ID of another block storage volume from which the current volume was created
+	SourceVolID string `json:"source_volid"`
+	// Arbitrary key-value pairs defined by the user.
+	Metadata map[string]string `json:"metadata"`
+	// UserID is the id of the user who created the volume.
+	UserID string `json:"user_id"`
+	// Indicates whether this is a bootable volume.
+	Bootable string `json:"bootable"`
+	// Encrypted denotes if the volume is encrypted.
+	Encrypted bool `json:"encrypted"`
+	// ReplicationStatus is the status of replication.
+	ReplicationStatus string `json:"replication_status"`
+	// ConsistencyGroupID is the consistency group ID.
+	ConsistencyGroupID string `json:"consistencygroup_id"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach"`
+
+	//Cloud hard disk uri self-description information.
+	Links []map[string]string `json:"links"`
+
+	//Whether it is a shared cloud drive.
+	//Shareable bool `json:"shareable"`
+	//Volume image metadata
+	VolumeImageMetadata map[string]string `json:"volume_image_metadata"`
+
+	//The tenant ID to which the cloud drive belongs.
+	TenantAttr string `json:"os-vol-tenant-attr:tenant_id"`
+
+	//The host name to which the cloud drive belongs.
+	HostAttr string `json:"os-vol-host-attr:host"`
+	//Reserved attribute
+	RepAttrDriverData string `json:"os-volume-replication:driver_data"`
+	//Reserved attribute
+	RepAttrExtendedStatus string `json:"os-volume-replication:extended_status"`
+	//Reserved attribute
+	MigAttrStat string `json:"os-vol-mig-status-attr:migstat"`
+	//Reserved attribute
+	MigAttrNameID string `json:"os-vol-mig-status-attr:name_id"`
+}
+
+type Attachment struct {
+	AttachedAt   time.Time `json:"-"`
+	AttachmentID string    `json:"attachment_id"`
+	Device       string    `json:"device"`
+	HostName     string    `json:"host_name"`
+	ID           string    `json:"id"`
+	ServerID     string    `json:"server_id"`
+	VolumeID     string    `json:"volume_id"`
+}
+
+// VolumeType 卷类型
+type VolumeType struct {
+	// Unique identifier for the volume type.
+	ID string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+}
+
+type Flavor struct {
+	// Specifies the ID of ECS specifications.
+	ID string `json:"id"`
+
+	// Specifies the name of the ECS specifications.
+	Name string `json:"name"`
+
+	// Specifies the number of CPU cores in the ECS specifications.
+	Vcpus string `json:"vcpus"`
+
+	// Specifies the memory size (MB) in the ECS specifications.
+	Ram int64 `json:"ram"`
+
+	// Specifies the system disk size in the ECS specifications.
+	// The value 0 indicates that the disk size is not limited.
+	Disk string `json:"disk"`
+
+	// Specifies shortcut links for ECS flavors.
+	Links []Link `json:"links"`
+
+	// Specifies extended ECS specifications.
+	OsExtraSpecs OsExtraSpecs `json:"os_extra_specs"`
+
+	// Reserved
+	Swap string `json:"swap"`
+
+	// Reserved
+	FlvEphemeral int64 `json:"OS-FLV-EXT-DATA:ephemeral"`
+
+	// Reserved
+	FlvDisabled bool `json:"OS-FLV-DISABLED:disabled"`
+
+	// Reserved
+	RxtxFactor int64 `json:"rxtx_factor"`
+
+	// Reserved
+	RxtxQuota string `json:"rxtx_quota"`
+
+	// Reserved
+	RxtxCap string `json:"rxtx_cap"`
+
+	// Reserved
+	AccessIsPublic bool `json:"os-flavor-access:is_public"`
+}
+
+type Link struct {
+	// Specifies the shortcut link marker name.
+	Rel string `json:"rel"`
+
+	// Provides the corresponding shortcut link.
+	Href string `json:"href"`
+
+	// Specifies the shortcut link type.
+	Type string `json:"type"`
+}
+
+type OsExtraSpecs struct {
+	// Specifies the ECS specifications types
+	PerformanceType string `json:"ecs:performancetype"`
+
+	// Specifies the resource type.
+	ResourceType string `json:"resource_type"`
+
+	// Specifies the generation of an ECS type
+	Generation string `json:"ecs:generation"`
+
+	// Specifies a virtualization type
+	VirtualizationEnvTypes string `json:"ecs:virtualization_env_types"`
+
+	// Indicates whether the GPU is passthrough.
+	PciPassthroughEnableGpu string `json:"pci_passthrough:enable_gpu"`
+
+	// Indicates the technology used on the G1 and G2 ECSs,
+	// including GPU virtualization and GPU passthrough.
+	PciPassthroughGpuSpecs string `json:"pci_passthrough:gpu_specs"`
+
+	// Indicates the model and quantity of passthrough-enabled GPUs on P1 ECSs.
+	PciPassthroughAlias string `json:"pci_passthrough:alias"`
+
+	// gpu info.wuzilin add
+	InfoGPUName string `json:"info:gpu:name,omitempty"`
+
+	// cpu
+	InfoCpuName string `json:"info:cpu:name,omitempty"`
+
+	CondOperationStatus string `json:"cond:operation:status"`
+
+	CondOperationAz string `json:"cond:operation:az"`
+
+	CondCompute string `json:"cond:compute"`
+
+	CondImage string `json:"cond:image"`
+
+	VifMaxNum string `json:"quota:vif_max_num"`
+
+	PhysicsMaxRate string `json:"quota:physics_max_rate"`
+
+	VifMultiqueueNum string `json:"quota:vif_multiqueue_num"`
+
+	MinRate string `json:"quota:min_rate"`
+
+	MaxRate string `json:"quota:max_rate"`
+
+	MaxPps string `json:"quota:max_pps"`
+
+	CPUSockets string `json:"hw:cpu_sockets"`
+
+	NumaNodes string `json:"hw:numa_nodes"`
+
+	CPUThreads string `json:"hw:cpu_threads"`
+
+	MemPageSize string `json:"hw:mem_page_size"`
+
+	ConnLimitTotal string `json:"quota:conn_limit_total"`
+
+	CPUCores string `json:"hw:cpu_cores"`
+
+	SpotExtraSpecs
+}
+
+// SpotExtraSpecs 增加spot属性
+type SpotExtraSpecs struct {
+	CondSpotBlockOperationAz     string `json:"cond:spot_block:operation:az"`
+	CondSpotBlockLdh             string `json:"cond:spot_block:operation:longest_duration_hours"`
+	CondSpotBlockLdc             string `json:"cond:spot_block:operation:longest_duration_count"`
+	CondSpotBlockInterruptPolicy string `json:"cond:spot_block:operation:interrupt_policy"`
+	CondSpotOperationAz          string `json:"cond:spot:operation:az"`
+	CondSpotOperationStatus      string `json:"cond:spot:operation:status"`
+}
+
+// EdgeImageInfo 边缘镜像基本字段
+type EdgeImageInfo struct {
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Status                string `json:"status"`
+	DiskFormat            string `json:"disk_format"`
+	MinDiskGigabytes      int    `json:"min_disk"`
+	MinRAMMegabytes       int    `json:"min_ram"`
+	Owner                 string `json:"owner"`
+	Protected             bool   `json:"protected"`
+	Visibility            string `json:"visibility"`
+	CreatedAt             string `json:"created_at"`
+	UpdatedAt             string `json:"updated_at"`
+	Self                  string `json:"self"`
+	Deleted               bool   `json:"deleted"`
+	VirtualEnvType        string `json:"virtual_env_type"`
+	DeletedAt             string `json:"deleted_at"`
+	RelatedJobID          string `json:"related_job_id"`
+	ImageType             string `json:"__imagetype"`
+	Platform              string `json:"__platform"`
+	OsType                string `json:"__os_type"`
+	OsVersion             string `json:"__os_version"`
+	IsRegistered          bool   `json:"__isregistered"`
+	SupportKvm            string `json:"__support_kvm,omitempty"`
+	SupportKvmGpuType     string `json:"__support_kvm_gpu_type,omitempty"`
+	SupportKvmAscend310   string `json:"__support_kvm_ascend_310,omitempty"`
+	SupportKvmHi1822Hiovs string `json:"__support_kvm_hi1822_hiovs,omitempty"`
+	SupportArm            string `json:"__support_arm,omitempty"`
+	HwFirmwareType        string `json:"hw_firmware_type,omitempty"`
+}
+
+// Coverage :Edge Coverage Rule
+type Coverage struct {
+	CoveragePolicy string         `json:"coverage_policy" required:"true"`
+	CoverageLevel  string         `json:"coverage_level" required:"true"`
+	CoverageSites  []CoverageSite `json:"coverage_sites,omitempty"`
+}
+
+// CoverageSite :Edge service coverage site
+type CoverageSite struct {
+	Site    string   `json:"site"`
+	Demands []Demand `json:"demands"`
+}
+
+// Demand
+type Demand struct {
+	Operator string `json:"operator" required:"true"`
+	Count    int    `json:"demand_count" required:"true"`
+}
+
+type ResourceOpts struct {
+	//Name is the name to assign to the newly launched server.
+	Name string `json:"name" required:"true"`
+
+	// ImageRef [optional; required if ImageName is not provided] is the ID or
+	// full URL to the image that contains the server's OS and initial state.
+	// Also optional if using the boot-from-volume extension.
+	ImageRef string `json:"image_ref" required:"true"`
+
+	// FlavorRef [optional; required if FlavorName is not provided] is the ID or
+	// full URL to the flavor that describes the server's specs.
+	FlavorRef string `json:"flavor_ref" required:"true"`
+
+	// UserData contains configuration information or scripts to use upon launch.
+	// Create will base64-encode it for you, if it isn't already.
+	UserData string `json:"user_data"`
+
+	// AdminPass sets the root user password. If not set, a randomly-generated
+	// password will be created and returned in the response.
+	AdminPass string `json:"admin_pass,omitempty"`
+
+	//secret for logging in server
+	KeyName string `json:"key_name,omitempty"`
+
+	// Networks dictates how this server will be attached to available networks.
+	// By default, the server will be attached to all isolated networks for the
+	// tenant.
+	NetConfig NetConfig `json:"net_config" required:"true"`
+
+	//Specifies the EIP bandwidth. If this parameter does not exist, no EIP is bound.
+	//If this parameter exists, an EIP is bound.
+	BandWidth *BandWidth `json:"bandwidth,omitempty"`
+
+	//the number of servers created
+	Count int `json:"count"`
+
+	//System disk configuration of the ECS
+	RootVolume RootVolume `json:"root_volume"`
+
+	//Specifies the data disk configuration of the ECS. Each data structure indicates
+	//a data disk to be created.
+	DataVolumes []DataVolume `json:"data_volumes,omitempty"`
+
+	//Specifies the security group of the ECS.
+	SecurityGroups []SecurityGroup `json:"security_groups,omitempty"`
+
+	// 边缘场景，待使用
+	EdgeScenes string `json:"edge_scenes,omitempty"`
+}
+
+// NetConfig
+type NetConfig struct {
+	VpcID   string     `json:"vpc_id" required:"true"`
+	Subnets []SubnetID `json:"subnets"`
+	NicNum  int        `json:"nic_num"`
+}
+
+// Subnet
+type SubnetID struct {
+	ID string `json:"id" required:"true"`
+}
+
+type BandWidth struct {
+	//BandWidth（Mbit/s）[1,300]。
+	Size int `json:"size,omitempty"`
+
+	//ShareTypde PER indicates exclusive, and WHOLE indicates shared.
+	ShareType string `json:"sharetype" required:"true"`
+
+	//ChargeMode
+	ChargeMode string `json:"chargemode,omitempty"`
+
+	//BandWidthID，When creating an elastic IP address for a bandwidth of the
+	//WHOLE type, you can specify the original shared bandwidth.
+	Id string `json:"id,omitempty"`
+}
+
+type RootVolume struct {
+	//the disk type of the ECS system disk. The disk type must match the disk
+	//type provided by the system.
+	VolumeType string `json:"volume_type" required:"true"`
+
+	//the system disk size. The unit is GB. The value ranges from 1 to 1024.
+	Size int `json:"size,omitempty"`
+}
+
+type DataVolume struct {
+	//the disk type of the ECS data disk. The disk type must match the disk
+	//type provided by the system.
+	VolumeType string `json:"volume_type" required:"true"`
+
+	//the data disk size in GB. The value ranges from 10 to 32768.
+	Size int `json:"size" required:"true"`
+}
+
+type SecurityGroup struct {
+	//云服务器组ID，UUID格式。
+	ID string `json:"id" required:"true"`
+}
+
+// KeyPair is an SSH key known to the OpenStack Cloud that is available to be
+// injected into servers.
+type KeyPair struct {
+	// Name is used to refer to this keypair from other services within this
+	// region.
+	Name string `json:"name"`
+
+	// Fingerprint is a short sequence of bytes that can be used to authenticate
+	// or validate a longer public key.
+	Fingerprint string `json:"fingerprint"`
+
+	// PublicKey is the public key from this pair, in OpenSSH format.
+	// "ssh-rsa AAAAB3Nz..."
+	PublicKey string `json:"public_key"`
+
+	// PrivateKey is the private key from this pair, in PEM format.
+	// "-----BEGIN RSA PRIVATE KEY-----\nMIICXA..."
+	// It is only present if this KeyPair was just returned from a Create call.
+	PrivateKey string `json:"private_key,omitempty"`
+
+	// UserID is the user who owns this KeyPair.
+	UserID string `json:"user_id,omitempty"`
+}
+
+// ReqSecurityGroupRuleEntity 创建安全组的规则的结构体
+type ReqSecurityGroupRuleEntity struct {
+	Description     string      `json:"description,omitempty"`
+	SecurityGroupID string      `json:"security_group_id"`
+	Direction       string      `json:"direction"`
+	EtherType       string      `json:"ethertype,omitempty"`
+	Protocol        string      `json:"protocol,omitempty"`
+	PortRangeMin    interface{} `json:"port_range_min"`
+	PortRangeMax    interface{} `json:"port_range_max"`
+	RemoteIPPrefix  string      `json:"remote_ip_prefix,omitempty"`
+	RemoteGroupID   string      `json:"remote_group_id,omitempty"`
+}
+
+// RegionSecurityGroupItem region级别的安全组信息
+type RegionSecurityGroupItem struct {
+	RegionID              string `json:"region_id,omitempty"`
+	RegionSecurityGroupID string `json:"region_security_group_id,omitempty"`
+}
+
+// RespSecurityGroupRuleEntity 获取安全组安全组的规则的结构体
+type RespSecurityGroupRuleEntity struct {
+	ID              string      `json:"id"`
+	Description     string      `json:"description"`
+	SecurityGroupID string      `json:"security_group_id"`
+	Direction       string      `json:"direction"`
+	EtherType       string      `json:"ethertype"`
+	Protocol        string      `json:"protocol"`
+	PortRangeMin    interface{} `json:"port_range_min"`
+	PortRangeMax    interface{} `json:"port_range_max"`
+	RemoteIPPrefix  string      `json:"remote_ip_prefix"`
+	RemoteGroupID   string      `json:"remote_group_id"`
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/requests.go
@@ -1,0 +1,131 @@
+package vpcs
+
+import (
+	"net/http"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// create request.
+type CreateOptsBuilder interface {
+	ToVPCCreateMap() (map[string]interface{}, error)
+}
+type CreateOpts struct {
+	//vpc name
+	Name string `json:"name" required:"true"`
+	//cidr,172.16.0.0/12~172.248.255.0/24
+	Cidr string `json:"cidr" required:"true"`
+
+	//mode，SYSTEM or CUSTOMER,SYSTEM： system will design and create subnet when you need;
+	// CUSTOMER: you should design and create by yourself
+	Mode string `json:"mode" required:"true"`
+}
+
+// ToSecurityGroupsCreateMap converts CreateOpts structures to map[string]interface{}
+func (opts CreateOpts) ToVPCCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "vpc")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+type UpdateOpts struct {
+	// Specifies the name of the VPC. The name must be unique for a
+	// tenant. The value is a string of no more than 64 characters and can contain digits,
+	// letters, underscores (_), and hyphens (-).
+	Name string `json:"name,omitempty"`
+
+	// Specifies the range of available subnets in the VPC. The value
+	// must be in CIDR format, for example, 192.168.0.0/16. The value ranges from 10.0.0.0/8
+	// to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to
+	// 192.168.255.0/24.
+	Cidr string `json:"cidr,omitempty"`
+}
+
+type UpdateOptsBuilder interface {
+	ToVPCUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToVPCUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "vpc")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Get get vpc detail
+func Get(client *golangsdk.ServiceClient, vpcID string) (r GetResult) {
+	getURL := GetURL(client, vpcID)
+
+	var resp *http.Response
+	resp, r.Err = client.Get(getURL, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+// Create create vpc
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVPCCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	createURL := CreateURL(client)
+
+	var resp *http.Response
+	resp, r.Err = client.Post(createURL, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+//Update update vpc info,name especially
+func Update(client *golangsdk.ServiceClient, vpcID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVPCUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	updateURL := UpdateURL(client, vpcID)
+
+	var resp *http.Response
+	resp, r.Err = client.Put(updateURL, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+//Delete delete the vpc
+func Delete(client *golangsdk.ServiceClient, vpcID string) (r DeleteResult) {
+	deleteURL := DeleteURL(client, vpcID)
+
+	var resp *http.Response
+	resp, r.Err = client.Delete(deleteURL, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/results.go
@@ -1,0 +1,67 @@
+package vpcs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/common"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (*common.VPC, error) {
+	var entity common.VPC
+	err := r.ExtractIntoStructPtr(&entity, "vpc")
+	return &entity, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*common.VPC, error) {
+	var entity common.VPC
+	err := r.ExtractIntoStructPtr(&entity, "vpc")
+	return &entity, err
+}
+
+type VpcPage struct {
+	pagination.LinkedPageBase
+}
+
+func ExtractVpcs(r pagination.Page) ([]common.VPC, error) {
+	var s struct {
+		Vpcs []common.VPC `json:"vpcs"`
+	}
+	err := r.(VpcPage).ExtractInto(&s)
+	return s.Vpcs, err
+}
+
+// IsEmpty checks whether a NetworkPage struct is empty.
+func (r VpcPage) IsEmpty() (bool, error) {
+	s, err := ExtractVpcs(r)
+	return len(s) == 0, err
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+func (r UpdateResult) Extract() (*common.VPC, error) {
+	var entity common.VPC
+	err := r.ExtractIntoStructPtr(&entity, "vpc")
+	return &entity, err
+}
+
+type UpdateStatusResult struct {
+	commonResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs/urls.go
@@ -1,0 +1,19 @@
+package vpcs
+
+import "github.com/huaweicloud/golangsdk"
+
+func CreateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("vpcs")
+}
+
+func DeleteURL(c *golangsdk.ServiceClient, vpcId string) string {
+	return c.ServiceURL("vpcs", vpcId)
+}
+
+func GetURL(c *golangsdk.ServiceClient, vpcId string) string {
+	return c.ServiceURL("vpcs", vpcId)
+}
+
+func UpdateURL(c *golangsdk.ServiceClient, vpcId string) string {
+	return c.ServiceURL("vpcs", vpcId)
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config.go
@@ -781,6 +781,13 @@ func (c *Config) gaussdbV3Client(region string) (*golangsdk.ServiceClient, error
 	return c.NewServiceClient("gaussdb", region)
 }
 
+// ********** client for edge / IoT **********
+
+// IECV1Client returns a ServiceClient for IEC Endpoint APIs
+func (c *Config) IECV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("iec", region)
+}
+
 // ********** client for Others **********
 func (c *Config) BssV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("bss", region)

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/endpoints.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/endpoints.go
@@ -296,6 +296,14 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v2",
 	},
 
+	// catalog for edge / IoT
+	"iec": ServiceCatalog{
+		Name:             "iecs",
+		Version:          "v1",
+		Scope:            "global",
+		WithOutProjectID: true,
+	},
+
 	// catalog for Others
 	"rts": ServiceCatalog{
 		Name:    "rts",

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/provider.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/provider.go
@@ -391,6 +391,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_identity_role":                   resourceIdentityRole(),
 			"huaweicloud_identity_role_assignment":        ResourceIdentityRoleAssignmentV3(),
 			"huaweicloud_identity_user":                   ResourceIdentityUserV3(),
+			"huaweicloud_iec_vpc":                         ResourceIecVpc(),
 			"huaweicloud_images_image":                    ResourceImsImage(),
 			"huaweicloud_kms_key":                         resourceKmsKeyV1(),
 			"huaweicloud_lb_certificate":                  ResourceCertificateV2(),

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_iec_vpc.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_iec_vpc.go
@@ -1,0 +1,138 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs"
+)
+
+func ResourceIecVpc() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceIecVpcV1Create,
+		Read:   resourceIecVpcV1Read,
+		Update: resourceIecVpcV1Update,
+		Delete: resourceIecVpcV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "SYSTEM",
+			},
+			"subnet_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIecVpcV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecV1Client, err := config.IECV1Client(GetRegion(d, config))
+
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	createOpts := vpcs.CreateOpts{
+		Name: d.Get("name").(string),
+		Cidr: d.Get("cidr").(string),
+		Mode: d.Get("mode").(string),
+	}
+
+	n, err := vpcs.Create(iecV1Client, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC VPC: %s", err)
+	}
+
+	log.Printf("[INFO] IEC VPC ID: %s", n.ID)
+	d.SetId(n.ID)
+
+	return resourceIecVpcV1Read(d, meta)
+}
+
+func resourceIecVpcV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecV1Client, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	n, err := vpcs.Get(iecV1Client, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving Huaweicloud IEC VPC")
+	}
+
+	d.Set("name", n.Name)
+	d.Set("cidr", n.Cidr)
+	d.Set("mode", n.Mode)
+	d.Set("subnet_num", n.SubnetNum)
+
+	return nil
+}
+
+func resourceIecVpcV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecV1Client, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	var updateOpts vpcs.UpdateOpts
+
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+	if d.HasChange("cidr") {
+		updateOpts.Cidr = d.Get("cidr").(string)
+	}
+
+	_, err = vpcs.Update(iecV1Client, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating Huaweicloud IEC VPC: %s", err)
+	}
+
+	return resourceIecVpcV1Read(d, meta)
+}
+
+func resourceIecVpcV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecV1Client, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	err = vpcs.Delete(iecV1Client, d.Id()).ExtractErr()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving Huaweicloud IEC VPC")
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c
+# github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
 github.com/huaweicloud/golangsdk/openstack
@@ -263,6 +263,8 @@ github.com/huaweicloud/golangsdk/openstack/identity/v3/projects
 github.com/huaweicloud/golangsdk/openstack/identity/v3/roles
 github.com/huaweicloud/golangsdk/openstack/identity/v3/tokens
 github.com/huaweicloud/golangsdk/openstack/identity/v3/users
+github.com/huaweicloud/golangsdk/openstack/iec/v1/common
+github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs
 github.com/huaweicloud/golangsdk/openstack/imageservice/v2/imagedata
 github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images
 github.com/huaweicloud/golangsdk/openstack/ims/v2/cloudimages
@@ -339,7 +341,11 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/pagination
+<<<<<<< HEAD
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225014516-43556a771b11
+=======
+# github.com/huaweicloud/terraform-provider-huaweicloud v1.20.2-0.20201225061100-2c08aa044351
+>>>>>>> add LB resources (#15)
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud
 # github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 github.com/jen20/awspolicyequivalence


### PR DESCRIPTION
The following resources were added:
data_source_sbercloud_obs_bucket_object
resource_sbercloud_obs_bucket_object
resource_sbercloud_obs_bucket_policy
resource_sbercloud_obs_bucket
```bash
make testacc TEST='./sbercloud' TESTARGS='-run TestAccObs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccObs -timeout 360m
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_website
=== CONT  TestAccObsBucketPolicy_s3
--- PASS: TestAccObsBucket_website (85.91s)
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucketObject_source (90.56s)
=== CONT  TestAccObsBucket_withEpsId
    provider_test.go:51: This environment does not support EPS_ID tests
--- SKIP: TestAccObsBucket_withEpsId (0.01s)
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucketPolicy_s3 (91.23s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_versioning (160.36s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_tags (86.36s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucket_lifecycle (87.06s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_basic (159.29s)
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucket_quota (87.10s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucket_logging (105.69s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucket_cors (89.43s)
--- PASS: TestAccObsBucketPolicy_basic (105.32s)
--- PASS: TestAccObsBucketObject_content (91.01s)
--- PASS: TestAccObsBucketPolicy_update (170.28s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   429.722s

make testacc TEST='./sbercloud' TESTARGS='-run TestAccHuaweiCloudObsBucketObjectDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccHuaweiCloudObsBucketObjectDataSource -timeout 360m
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_content
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_content
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_source
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_source
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_content
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_source
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_content (157.95s)
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_allParams (158.66s)
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_source (159.90s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   159.933s
```