### PR TITLE
Fix VPC acceptance tests

### DIFF
--- a/sbercloud/data_source_sbercloud_vpc_test.go
+++ b/sbercloud/data_source_sbercloud_vpc_test.go
@@ -2,6 +2,7 @@ package sbercloud
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,19 +12,19 @@ import (
 
 func TestAccVpcV1DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	tmp := strconv.Itoa(acctest.RandIntRange(1, 254))
+	cidr := fmt.Sprintf("172.16.%s.0/24", tmp)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceVpcV1Config(rName),
+				Config: testAccDataSourceVpcV1Config(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceVpcV1Check("data.sbercloud_vpc.by_id", rName),
 					testAccDataSourceVpcV1Check("data.sbercloud_vpc.by_cidr", rName),
 					testAccDataSourceVpcV1Check("data.sbercloud_vpc.by_name", rName),
-					resource.TestCheckResourceAttr(
-						"data.sbercloud_vpc.by_id", "shared", "false"),
 					resource.TestCheckResourceAttr(
 						"data.sbercloud_vpc.by_id", "status", "OK"),
 				),
@@ -62,11 +63,11 @@ func testAccDataSourceVpcV1Check(n, rName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourceVpcV1Config(rName string) string {
+func testAccDataSourceVpcV1Config(rName, cidr string) string {
 	return fmt.Sprintf(`
 resource "sbercloud_vpc" "test" {
   name = "%s"
-  cidr = "172.16.10.0/24"
+  cidr = "%s"
 }
 
 data "sbercloud_vpc" "by_id" {
@@ -80,5 +81,5 @@ data "sbercloud_vpc" "by_cidr" {
 data "sbercloud_vpc" "by_name" {
   name = sbercloud_vpc.test.name
 }
-`, rName)
+`, rName, cidr)
 }


### PR DESCRIPTION
This PR fixes some VPC acceptance tests and adds missed one.

For now all VPC tests are done well:
```
make testacc TEST='./sbercloud' TESTARGS='-run TestAccVpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccVpc -timeout 360m -parallel=4
=== RUN   TestAccVpcRouteV2DataSource_basic
=== PAUSE TestAccVpcRouteV2DataSource_basic
=== RUN   TestAccVpcSubnetIdsV2DataSource_basic
=== PAUSE TestAccVpcSubnetIdsV2DataSource_basic
=== RUN   TestAccVpcSubnetV1DataSource_basic
=== PAUSE TestAccVpcSubnetV1DataSource_basic
=== RUN   TestAccVpcV1DataSource_basic
=== PAUSE TestAccVpcV1DataSource_basic
=== RUN   TestAccVpcBandWidthV2_basic
=== PAUSE TestAccVpcBandWidthV2_basic
=== RUN   TestAccVpcBandWidthV2_WithEpsId
=== PAUSE TestAccVpcBandWidthV2_WithEpsId
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== RUN   TestAccVpcV1EIP_share
=== PAUSE TestAccVpcV1EIP_share
=== RUN   TestAccVpcPeeringConnectionV2_basic
=== PAUSE TestAccVpcPeeringConnectionV2_basic
=== RUN   TestAccVpcRouteV2_basic
=== PAUSE TestAccVpcRouteV2_basic
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcRouteV2DataSource_basic
=== CONT  TestAccVpcV1EIP_share
=== CONT  TestAccVpcBandWidthV2_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcBandWidthV2_basic (26.29s)
=== CONT  TestAccVpcBandWidthV2_WithEpsId
--- PASS: TestAccVpcV1EIP_basic (27.36s)
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1EIP_share (37.17s)
=== CONT  TestAccVpcV1_WithEpsId
--- PASS: TestAccVpcBandWidthV2_WithEpsId (17.33s)
=== CONT  TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcRouteV2DataSource_basic (55.06s)
=== CONT  TestAccVpcV1DataSource_basic
--- PASS: TestAccVpcV1_WithEpsId (27.05s)
=== CONT  TestAccVpcPeeringConnectionV2_basic
--- PASS: TestAccVpcV1_basic (40.42s)
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcV1DataSource_basic (29.82s)
=== CONT  TestAccVpcSubnetIdsV2DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (52.11s)
=== CONT  TestAccVpcRouteV2_basic
--- PASS: TestAccVpcPeeringConnectionV2_basic (53.40s)
--- PASS: TestAccVpcSubnetV1_basic (66.05s)
--- PASS: TestAccVpcSubnetIdsV2DataSource_basic (57.45s)
--- PASS: TestAccVpcRouteV2_basic (53.11s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   149.398s
```