### PR TITLE
Fix NAT acceptance tests

### DIFF
--- a/sbercloud/resource_sbercloud_nat_gateway_test.go
+++ b/sbercloud/resource_sbercloud_nat_gateway_test.go
@@ -48,6 +48,26 @@ func TestAccNatGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccNatGateway_withEpsId(t *testing.T) {
+	randSuffix := acctest.RandString(5)
+	resourceName := "sbercloud_nat_gateway.nat_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNatV2GatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNatV2Gateway_epsId(randSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNatV2GatewayExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", SBC_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNatV2GatewayDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	natClient, err := config.NatGatewayClient(SBC_REGION_NAME)
@@ -121,11 +141,11 @@ func testAccNatV2Gateway_basic(suffix string) string {
 %s
 
 resource "sbercloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-basic-%s"
-  description         = "test for terraform"
-  spec                = "1"
-  internal_network_id = sbercloud_vpc_subnet.subnet_1.id
-  router_id           = sbercloud_vpc.vpc_1.id
+  name        = "nat-gateway-basic-%s"
+  description = "test for terraform"
+  spec        = "1"
+  vpc_id      = sbercloud_vpc.vpc_1.id
+  subnet_id   = sbercloud_vpc_subnet.subnet_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)
 }
@@ -135,12 +155,26 @@ func testAccNatV2Gateway_update(suffix string) string {
 %s
 
 resource "sbercloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-updated-%s"
-  description         = "test for terraform updated"
-  spec                = "2"
-  internal_network_id = sbercloud_vpc_subnet.subnet_1.id
-  router_id           = sbercloud_vpc.vpc_1.id
-
+  name        = "nat-gateway-updated-%s"
+  description = "test for terraform updated"
+  spec        = "2"
+  vpc_id      = sbercloud_vpc.vpc_1.id
+  subnet_id   = sbercloud_vpc_subnet.subnet_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)
+}
+
+func testAccNatV2Gateway_epsId(suffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_nat_gateway" "nat_1" {
+  name                  = "nat-gateway-eps-%s"
+  description           = "test for terraform"
+  spec                  = "1"
+  vpc_id                = sbercloud_vpc.vpc_1.id
+  subnet_id             = sbercloud_vpc_subnet.subnet_1.id
+  enterprise_project_id = "%s"
+}
+	`, testAccNatPreCondition(suffix), suffix, SBC_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/sbercloud/resource_sbercloud_nat_snat_rule_test.go
+++ b/sbercloud/resource_sbercloud_nat_snat_rule_test.go
@@ -106,16 +106,16 @@ resource "sbercloud_vpc_eip" "eip_1" {
 }
 
 resource "sbercloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-basic-%s"
-  description         = "test for terraform"
-  spec                = "1"
-  internal_network_id = sbercloud_vpc_subnet.subnet_1.id
-  router_id           = sbercloud_vpc.vpc_1.id
+  name        = "nat-gateway-basic-%s"
+  description = "test for terraform"
+  spec        = "1"
+  vpc_id      = sbercloud_vpc.vpc_1.id
+  subnet_id   = sbercloud_vpc_subnet.subnet_1.id
 }
 
 resource "sbercloud_nat_snat_rule" "snat_1" {
   nat_gateway_id = sbercloud_nat_gateway.nat_1.id
-  network_id     = sbercloud_vpc_subnet.subnet_1.id
+  subnet_id      = sbercloud_vpc_subnet.subnet_1.id
   floating_ip_id = sbercloud_vpc_eip.eip_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)


### PR DESCRIPTION
This PR fixes some NAT acceptance tests and adds missed test with enterprise project id.

Now all NAT acceptance tests are done successfully:

```
make testacc TEST='./sbercloud' TESTARGS='-run TestAccNat'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccNat -timeout 360m -parallel=4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_withEpsId
=== PAUSE TestAccNatGateway_withEpsId
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGateway_basic
=== CONT  TestAccNatSnatRule_basic
=== CONT  TestAccNatGateway_withEpsId
--- PASS: TestAccNatGateway_withEpsId (69.54s)
=== CONT  TestAccNatDnat_protocol
--- PASS: TestAccNatGatewayDataSource_basic (72.63s)
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatGateway_basic (80.35s)
--- PASS: TestAccNatSnatRule_basic (91.62s)
--- PASS: TestAccNatDnat_protocol (195.76s)
--- PASS: TestAccNatDnat_basic (195.68s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   268.780s
```