### PR TITLE
Fix OBS acceptance tests

### DIFF
--- a/sbercloud/provider_test.go
+++ b/sbercloud/provider_test.go
@@ -12,13 +12,15 @@ import (
 )
 
 var (
-	SBC_REGION_NAME                = os.Getenv("SBC_REGION_NAME")
+	SBC_ACCESS_KEY                 = os.Getenv("SBC_ACCESS_KEY")
 	SBC_ACCOUNT_NAME               = os.Getenv("SBC_ACCOUNT_NAME")
 	SBC_ADMIN                      = os.Getenv("SBC_ADMIN")
 	SBC_DOMAIN_ID                  = os.Getenv("SBC_DOMAIN_ID")
 	SBC_DOMAIN_NAME                = os.Getenv("SBC_DOMAIN_NAME")
 	SBC_ENTERPRISE_PROJECT_ID_TEST = os.Getenv("SBC_ENTERPRISE_PROJECT_ID_TEST")
 	SBC_PROJECT_ID                 = os.Getenv("SBC_PROJECT_ID")
+	SBC_REGION_NAME                = os.Getenv("SBC_REGION_NAME")
+	SBC_SECRET_KEY                 = os.Getenv("SBC_SECRET_KEY")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -50,6 +52,12 @@ func testAccPreCheckAdminOnly(t *testing.T) {
 func testAccPreCheckEpsID(t *testing.T) {
 	if SBC_ENTERPRISE_PROJECT_ID_TEST == "" {
 		t.Skip("This environment does not support EPS_ID tests")
+	}
+}
+
+func testAccPreCheckOBS(t *testing.T) {
+	if SBC_ACCESS_KEY == "" || SBC_SECRET_KEY == "" {
+		t.Skip("SBC_ACCESS_KEY and SBC_SECRET_KEY must be set for OBS acceptance tests")
 	}
 }
 

--- a/sbercloud/resource_sbercloud_obs_bucket_policy_test.go
+++ b/sbercloud/resource_sbercloud_obs_bucket_policy_test.go
@@ -21,7 +21,7 @@ func TestAccObsBucketPolicy_basic(t *testing.T) {
 		name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -56,7 +56,7 @@ func TestAccObsBucketPolicy_update(t *testing.T) {
 		name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func TestAccObsBucketPolicy_s3(t *testing.T) {
 		name, name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{

--- a/sbercloud/resource_sbercloud_obs_bucket_test.go
+++ b/sbercloud/resource_sbercloud_obs_bucket_test.go
@@ -15,7 +15,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -77,7 +77,7 @@ func TestAccObsBucket_tags(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func TestAccObsBucket_versioning(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -131,7 +131,7 @@ func TestAccObsBucket_logging(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -151,7 +151,7 @@ func TestAccObsBucket_quota(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -172,7 +172,7 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -219,7 +219,7 @@ func TestAccObsBucket_website(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -242,7 +242,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 	resourceName := "sbercloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckOBS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -348,7 +348,7 @@ func testAccObsBucketName(randInt int) string {
 }
 
 func testAccObsBucketDomainName(randInt int) string {
-	return fmt.Sprintf("tf-test-bucket-%d.obs.%s.myhuaweicloud.com", randInt, SBC_REGION_NAME)
+	return fmt.Sprintf("tf-test-bucket-%d.obs.%s.hc.sbercloud.ru", randInt, SBC_REGION_NAME)
 }
 
 func testAccObsBucket_basic(randInt int) string {


### PR DESCRIPTION
This PR fixes some OBS acceptance tests and adds missed one.

Now all OBS acceptance tests are done successfully:
```
make testacc TEST='./sbercloud' TESTARGS='-run TestAccObs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccObs -timeout 360m -parallel=4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucket_versioning
=== CONT  TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (7.09s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucketPolicy_s3 (7.31s)
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_versioning (12.53s)
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketObject_source (12.63s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucket_withEpsId (6.29s)
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_cors (6.69s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketPolicy_basic (7.43s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucket_tags (6.35s)
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucketObject_content (6.65s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucketPolicy_update (11.93s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_quota (6.21s)
--- PASS: TestAccObsBucket_lifecycle (6.33s)
--- PASS: TestAccObsBucket_basic (11.47s)
--- PASS: TestAccObsBucket_logging (7.80s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   32.796s
```