### PR TITLE
Update go to 1.16 in setup-go action to enable darwin/arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Goreleaser's GitHub action disables builds for darwin/arm64 with go prior 1.16 because old go versions consider darwin/arm64 as iOS arch, not apple silicon. Update go to 1.16 allowed goreleaser to prepare darwin/arm64 artifacts.

https://goreleaser.com/deprecations/#builds-for-darwinarm64

