### PR TITLE
Add GES Graph resource

### DIFF
--- a/docs/resources/ges_graph.md
+++ b/docs/resources/ges_graph.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Graph Engine Service (GES)"
+---
+
+# sbercloud\_ges\_graph
+
+GES graph management
+
+## Example Usage
+
+### create an empty graph
+
+```hcl
+resource "sbercloud_networking_secgroup" "secgroup" {
+  name        = "terraform_test_security_group"
+  description = "terraform security group acceptance test"
+}
+
+resource "sbercloud_ges_graph" "graph" {
+  availability_zone = "{{ availability_zone }}"
+  graph_size_type   = 0
+  name              = "terraform_ges_graph_test"
+  region            = "{{ region_name }}"
+  security_group_id = sbercloud_networking_secgroup.secgroup.id
+  subnet_id         = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `availability_zone` - (Required, String, ForceNew) Indicates availability zone.  Changing this parameter will create a new resource.
+
+* `graph_size_type` - (Required, String, ForceNew) Indicates the graph size type.   0: indicates 10 thousand edges.   1:
+  indicates 1 million edges.   2: indicates 10 million edges.   3:
+  indicates 100 million edges.   4: indicates 1 billion edges.   5:
+  indicates 10 billion edges.   6: indicates 100 billion edges.  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Indicates the graph name.  Changing this parameter will create a new resource.
+
+* `region` - (Required, String, ForceNew) Indicates the region code.  Changing this parameter will create a new resource.
+
+* `security_group_id` - (Required, String, ForceNew) Indicates the security group ID.  Changing this parameter will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Indicates the subnet ID in the specified VPC.  Changing this parameter will create a new resource.
+
+* `vpc_id` - (Required, String, ForceNew) Indicates the VPC ID.  Changing this parameter will create a new resource.
+
+* `auto_assign` - (Optional, Bool, ForceNew) Indicates whether to assign a new eip to the graph automatically.  Changing this parameter will create a new resource.
+
+* `eip_id` - (Optional, String, ForceNew) Indicates the ID of an EIP.  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `created` - Indicates the time when a graph is created.
+
+* `edgeset_path` - Indicates the OBS path of the edge data set. Structure is documented below.
+
+* `private_ip` - Indicates the private network access address of a graph instance.
+  Users can access the instance using the IP address through the ECS
+  deployed on the private network.
+
+* `public_ip` - Indicates the public network access address of a graph instance.
+  Users can access the instance using the IP address from the Internet.
+
+* `schema_path` - Indicates the path for storing the metadata file. Structure is documented below.
+
+* `version` - Indicates the graph version.
+
+* `vertexset_path` - Indicates the OBS path of the vertex data set. Structure is documented below.
+
+The `edgeset_path` block contains:
+
+* `path` - Indicates the OBS storage path, excluding OBS endpoint.
+
+* `status` - Indicates the OBS file import status:   success: Imported
+  successfully.   partiallyFailed: Partially failed.   failed:
+  Failed to import the file.
+
+The `schema_path` block contains:
+
+* `path` - Indicates the OBS storage path, excluding OBS endpoint.
+
+* `status` - Indicates the OBS file import status:
+success: Imported successfully. partiallyFailed: Partially failed. failed: Failed to import the file.
+
+The `vertexset_path` block contains:
+
+* `path` - Indicates the OBS storage path, excluding OBS endpoint.
+
+* `status` - Indicates the OBS file import status:
+success: Imported successfully. partiallyFailed: Partially failed. failed: Failed to import the file.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 30 minute.
+- `delete` - Default is 30 minute.
+

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -165,6 +165,7 @@ func Provider() terraform.ResourceProvider {
 			"sbercloud_evs_snapshot":              huaweicloud.ResourceEvsSnapshotV2(),
 			"sbercloud_evs_volume":                huaweicloud.ResourceEvsStorageVolumeV3(),
 			"sbercloud_fgs_function":              huaweicloud.ResourceFgsFunctionV2(),
+			"sbercloud_ges_graph":                 huaweicloud.ResourceGesGraphV1(),
 			"sbercloud_identity_agency":           huaweicloud.ResourceIAMAgencyV3(),
 			"sbercloud_identity_role_assignment":  huaweicloud.ResourceIdentityRoleAssignmentV3(),
 			"sbercloud_identity_user":             huaweicloud.ResourceIdentityUserV3(),

--- a/sbercloud/resource_sbercloud_ges_graph_test.go
+++ b/sbercloud/resource_sbercloud_ges_graph_test.go
@@ -1,0 +1,122 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccGesGraphV1_basic(t *testing.T) {
+	name := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGesGraphV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGesGraphV1_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGesGraphV1Exists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccGesGraphV1_basic(name string) string {
+	return fmt.Sprintf(`
+data "sbercloud_availability_zones" "test" {}
+
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "sbercloud_vpc_subnet" "test" {
+  name          = "%s"
+  cidr          = "192.168.0.0/24"
+  gateway_ip    = "192.168.0.1"
+  primary_dns   = "100.125.1.250"
+  secondary_dns = "100.125.21.250"
+  vpc_id        = sbercloud_vpc.test.id
+}
+
+resource "sbercloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "sbercloud_ges_graph" "graph" {
+  availability_zone = data.sbercloud_availability_zones.test.names[1]
+  graph_size_type   = 0
+  name              = "%s"
+  region            = "%s"
+  security_group_id = sbercloud_networking_secgroup.test.id
+  subnet_id         = sbercloud_vpc_subnet.test.id
+  vpc_id            = sbercloud_vpc.test.id
+}
+	`, name, name, name, name, SBC_REGION_NAME)
+}
+
+func testAccCheckGesGraphV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	client, err := config.GesV1Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating sdk client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_ges_graph" {
+			continue
+		}
+
+		url, err := replaceVarsForTest(rs, "graphs/{id}")
+		if err != nil {
+			return err
+		}
+		url = client.ServiceURL(url)
+
+		_, err = client.Get(url, nil, &golangsdk.RequestOpts{
+			MoreHeaders: map[string]string{"Content-Type": "application/json"}})
+		if err == nil {
+			return fmt.Errorf("sbercloud_ges_graph still exists at %s", url)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckGesGraphV1Exists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.GesV1Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating sdk client, err=%s", err)
+		}
+
+		rs, ok := s.RootModule().Resources["sbercloud_ges_graph.graph"]
+		if !ok {
+			return fmt.Errorf("Error checking sbercloud_ges_graph.graph exist, err=not found this resource")
+		}
+
+		url, err := replaceVarsForTest(rs, "graphs/{id}")
+		if err != nil {
+			return fmt.Errorf("Error checking sbercloud_ges_graph.graph exist, err=building url failed: %s", err)
+		}
+		url = client.ServiceURL(url)
+
+		_, err = client.Get(url, nil, &golangsdk.RequestOpts{
+			MoreHeaders: map[string]string{"Content-Type": "application/json"}})
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return fmt.Errorf("sbercloud_ges_graph.graph is not exist")
+			}
+			return fmt.Errorf("Error checking sbercloud_ges_graph.graph exist, err=send request failed: %s", err)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This PR adds `sbercloud_ges_graph` resource.

This closes #75 

All acceptance tests are done:
```
make testacc TEST='./sbercloud' TESTARGS='-run TestAccGes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccGes -timeout 360m -parallel=4
=== RUN   TestAccGesGraphV1_basic
=== PAUSE TestAccGesGraphV1_basic
=== CONT  TestAccGesGraphV1_basic
--- PASS: TestAccGesGraphV1_basic (996.96s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   997.484s
```