### PR TITLE
Add VPN resources

### DIFF
--- a/docs/resources/vpnaas_endpoint_group.md
+++ b/docs/resources/vpnaas_endpoint_group.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+---
+
+# sbercloud\_vpnaas\_endpoint\_group
+
+Manages a Endpoint Group resource within SberCloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_vpnaas_endpoint_group" "group_1" {
+  name = "Group 1"
+  type = "cidr"
+  endpoints = ["10.2.0.0/24",
+        "10.3.0.0/24",]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the V2 Networking client.
+    A Networking client is needed to create an endpoint group. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    group.
+
+* `name` - (Optional) The name of the group. Changing this updates the name of
+    the existing group.
+
+* `description` - (Optional) The human-readable description for the group.
+    Changing this updates the description of the existing group.
+
+* `type` -  (Optional) The type of the endpoints in the group. A valid value is subnet, cidr, network, router, or vlan.
+    Changing this creates a new group.
+
+* `endpoints` - (Optional) List of endpoints of the same type, for the endpoint group. The values will depend on the type.
+    Changing this creates a new group.
+
+* `value_specs` - (Optional) Map of additional options.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `update` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+Groups can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_vpnaas_endpoint_group.group_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```

--- a/docs/resources/vpnaas_ike_policy.md
+++ b/docs/resources/vpnaas_ike_policy.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+---
+
+# sbercloud\_vpnaas\_ike\_policy
+
+Manages a IKE policy resource within SberCloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_vpnaas_ike_policy" "policy_1" {
+  name = "my_policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the V2 Networking client.
+    A Networking client is needed to create a VPN service. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    service.
+
+* `name` - (Optional) The name of the policy. Changing this updates the name of
+    the existing policy.
+
+* `description` - (Optional) The human-readable description for the policy.
+    Changing this updates the description of the existing policy.
+
+* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are md5, sha1, sha2-256, sha2-384, sha2-512.
+    Default is sha1. Changing this updates the algorithm of the existing policy.
+
+* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are 3des, aes-128, aes-192 and so on.
+    The default value is aes-128. Changing this updates the existing policy.
+
+* `pfs` - (Optional) The perfect forward secrecy mode. Valid values are Group2, Group5 and Group14. Default is Group5.
+    Changing this updates the existing policy.
+
+* `phase1_negotiation_mode` - (Optional) The IKE mode. A valid value is main, which is the default.
+    Changing this updates the existing policy.
+
+* `ike_version` - (Optional) The IKE mode. A valid value is v1 or v2. Default is v1.
+    Changing this updates the existing policy.
+
+* `lifetime` - (Optional) The lifetime of the security association. Consists of Unit and Value.
+    - `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
+    Default is seconds.
+    - `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
+    Default is 3600.
+
+* `value_specs` - (Optional) Map of additional options.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+
+## Import
+
+Services can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_vpnaas_ike_policy.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```

--- a/docs/resources/vpnaas_ipsec_policy.md
+++ b/docs/resources/vpnaas_ipsec_policy.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+---
+
+# sbercloud\_vpnaas\_ipsec\_policy
+
+Manages a IPSec policy resource within SberCloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+  name = "my_policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the V2 Networking client.
+    A Networking client is needed to create an IPSec policy. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    policy.
+
+* `name` - (Optional) The name of the policy. Changing this updates the name of
+    the existing policy.
+
+* `description` - (Optional) The human-readable description for the policy.
+    Changing this updates the description of the existing policy.
+
+* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are md5, sha1, sha2-256, sha2-384, sha2-512.
+    Default is sha1. Changing this updates the algorithm of the existing policy.
+
+* `encapsulation_mode` - (Optional) The encapsulation mode. Valid values are tunnel and transport. Default is tunnel.
+    Changing this updates the existing policy.
+
+* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are 3des, aes-128, aes-192 and so on.
+    The default value is aes-128. Changing this updates the existing policy.
+
+* `pfs` - (Optional) The perfect forward secrecy mode. Valid values are Group2, Group5 and Group14. Default is Group5.
+    Changing this updates the existing policy.
+
+* `transform_protocol` - (Optional) The transform protocol. Valid values are ESP, AH and AH-ESP.
+    Changing this updates the existing policy. Default is ESP.
+
+* `lifetime` - (Optional) The lifetime of the security association. Consists of Unit and Value.
+    - `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
+    Default is seconds.
+    - `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
+    Default is 3600.
+
+* `value_specs` - (Optional) Map of additional options.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+
+## Import
+
+Policies can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_vpnaas_ipsec_policy.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```

--- a/docs/resources/vpnaas_service.md
+++ b/docs/resources/vpnaas_service.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+---
+
+# sbercloud\_vpnaas\_service
+
+Manages a VPN service resource within SberCloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_vpnaas_service" "service_1" {
+  name           = "my_service"
+  router_id      = "14a75700-fc03-4602-9294-26ee44f366b3"
+  admin_state_up = "true"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the V2 Networking client.
+    A Networking client is needed to create a VPN service. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    service.
+
+* `name` - (Optional) The name of the service. Changing this updates the name of
+    the existing service.
+
+* `description` - (Optional) The human-readable description for the service.
+    Changing this updates the description of the existing service.
+
+* `admin_state_up` - (Optional) The administrative state of the resource.
+    Can either be up(true) or down (false). Defaults to `true`.
+    Changing this updates the administrative state of the existing service.
+
+* `subnet_id` - (Optional) SubnetID is the ID of the subnet. Default is null.
+
+* `router_id` - (Required) The ID of the router. Changing this creates a new service.
+
+* `value_specs` - (Optional) Map of additional options.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `status` - Indicates whether IPsec VPN service is currently operational. Values are ACTIVE, DOWN, BUILD, ERROR, PENDING_CREATE, PENDING_UPDATE, or PENDING_DELETE.
+* `external_v6_ip` - The read-only external (public) IPv6 address that is used for the VPN service.
+* `external_v4_ip` - The read-only external (public) IPv4 address that is used for the VPN service.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `update` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+Services can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_vpnaas_service.service_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```

--- a/docs/resources/vpnaas_site_connection.md
+++ b/docs/resources/vpnaas_site_connection.md
@@ -1,0 +1,112 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+---
+
+# sbercloud\_vpnaas\_site\_connection
+
+Manages a IPSec site connection resource within SberCloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_vpnaas_site_connection" "conn_1" {
+  name              = "connection_1"
+  ikepolicy_id      = sbercloud_vpnaas_ike_policy.policy_2.id
+  ipsecpolicy_id    = sbercloud_vpnaas_ipsec_policy.policy_1.id
+  vpnservice_id     = sbercloud_vpnaas_service.service_1.id
+  psk               = "secret"
+  peer_address      = "192.168.10.1"
+  local_ep_group_id = sbercloud_vpnaas_endpoint_group.group_2.id
+  peer_ep_group_id  = sbercloud_vpnaas_endpoint_group.group_1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the V2 Networking client.
+    A Networking client is needed to create an IPSec site connection. If omitted, the
+    `region` argument of the provider is used. Changing this creates a new
+    site connection.
+
+* `name` - (Optional) The name of the connection. Changing this updates the name of
+    the existing connection.
+
+* `description` - (Optional) The human-readable description for the connection.
+    Changing this updates the description of the existing connection.
+
+* `admin_state_up` - (Optional) The administrative state of the resource.
+    Can either be up(true) or down(false). Defaults to `true`.
+    Changing this updates the administrative state of the existing connection.
+
+* `ikepolicy_id` - (Required) The ID of the IKE policy. Changing this creates a new connection.
+
+* `vpnservice_id` - (Required) The ID of the VPN service. Changing this creates a new connection.
+
+* `local_ep_group_id` - (Optional) The ID for the endpoint group that contains private subnets for the local side of the connection.
+    You must specify this parameter with the peer_ep_group_id parameter unless
+	in backward- compatible mode where peer_cidrs is provided with a subnet_id for the VPN service.
+    Changing this updates the existing connection.
+
+* `ipsecpolicy_id` - (Required) The ID of the IPsec policy. Changing this creates a new connection.
+
+* `peer_id` - (Required) The peer router identity for authentication. A valid value is an IPv4 address, IPv6 address, e-mail address, key ID, or FQDN.
+	Typically, this value matches the peer_address value.
+	Changing this updates the existing policy.
+
+* `peer_ep_group_id` - (Optional) The ID for the endpoint group that contains private CIDRs in the form < net_address > / < prefix > for the peer side of the connection.
+	You must specify this parameter with the local_ep_group_id parameter unless in backward-compatible mode
+	where peer_cidrs is provided with a subnet_id for the VPN service.
+
+* `local_id` - (Optional) An ID to be used instead of the external IP address for a virtual router used in traffic between instances on different networks in east-west traffic.
+	Most often, local ID would be domain name, email address, etc.
+	If this is not configured then the external IP address will be used as the ID.
+
+* `peer_address` - (Required) The peer gateway public IPv4 or IPv6 address or FQDN.
+
+* `psk` - (Required) The pre-shared key. A valid value is any string.
+
+* `initiator` - (Optional) A valid value is response-only or bi-directional. Default is bi-directional.
+
+* `peer_cidrs` - (Optional) Unique list of valid peer private CIDRs in the form < net_address > / < prefix > .
+
+* `dpd` - (Optional) A dictionary with dead peer detection (DPD) protocol controls.
+    - `action` - (Optional) The dead peer detection (DPD) action.
+		A valid value is clear, hold, restart, disabled, or restart-by-peer.
+		Default value is hold.
+
+    - `timeout` - (Optional) The dead peer detection (DPD) timeout in seconds.
+		A valid value is a positive integer that is greater than the DPD interval value.
+		Default is 120.
+
+    - `interval` - (Optional) The dead peer detection (DPD) interval, in seconds.
+		A valid value is a positive integer.
+		Default is 30.
+
+* `mtu` -  (Optional) The maximum transmission unit (MTU) value to address fragmentation.
+	Minimum value is 68 for IPv4, and 1280 for IPv6.
+
+* `value_specs` - (Optional) Map of additional options.
+
+* `tags` - (Optional) The key/value pairs to associate with the connection.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `update` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+Site Connections can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_vpnaas_site_connection.conn_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -206,6 +206,11 @@ func Provider() terraform.ResourceProvider {
 			"sbercloud_vpc_route":                 huaweicloud.ResourceVPCRouteV2(),
 			"sbercloud_vpc_peering_connection":    huaweicloud.ResourceVpcPeeringConnectionV2(),
 			"sbercloud_vpc_subnet":                huaweicloud.ResourceVpcSubnetV1(),
+			"sbercloud_vpnaas_endpoint_group":     huaweicloud.ResourceVpnEndpointGroupV2(),
+			"sbercloud_vpnaas_ike_policy":         huaweicloud.ResourceVpnIKEPolicyV2(),
+			"sbercloud_vpnaas_ipsec_policy":       huaweicloud.ResourceVpnIPSecPolicyV2(),
+			"sbercloud_vpnaas_service":            huaweicloud.ResourceVpnServiceV2(),
+			"sbercloud_vpnaas_site_connection":    huaweicloud.ResourceVpnSiteConnectionV2(),
 			// Legacy
 			"sbercloud_identity_role_assignment_v3":  huaweicloud.ResourceIdentityRoleAssignmentV3(),
 			"sbercloud_identity_user_v3":             huaweicloud.ResourceIdentityUserV3(),

--- a/sbercloud/resource_sbercloud_vpnaas_endpoint_group_test.go
+++ b/sbercloud/resource_sbercloud_vpnaas_endpoint_group_test.go
@@ -1,0 +1,109 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/endpointgroups"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccVpnGroupV2_basic(t *testing.T) {
+	var group endpointgroups.EndpointGroup
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEndpointGroupV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointGroupV2_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointGroupV2Exists(
+						"sbercloud_vpnaas_endpoint_group.group_1", &group),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_endpoint_group.group_1", "name", &group.Name),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_endpoint_group.group_1", "type", &group.Type),
+				),
+			},
+			{
+				Config: testAccEndpointGroupV2_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointGroupV2Exists(
+						"sbercloud_vpnaas_endpoint_group.group_1", &group),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_endpoint_group.group_1", "name", &group.Name),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_endpoint_group.group_1", "type", &group.Type),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEndpointGroupV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_vpnaas_group" {
+			continue
+		}
+		_, err = endpointgroups.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("EndpointGroup (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckEndpointGroupV2Exists(n string, group *endpointgroups.EndpointGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+		}
+
+		var found *endpointgroups.EndpointGroup
+
+		found, err = endpointgroups.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*group = *found
+
+		return nil
+	}
+}
+
+var testAccEndpointGroupV2_basic = `
+	resource "sbercloud_vpnaas_endpoint_group" "group_1" {
+		name = "Group 1"
+		type = "cidr"
+		endpoints = ["10.3.0.0/24",
+			"10.2.0.0/24",]
+	}
+`
+
+var testAccEndpointGroupV2_update = `
+	resource "sbercloud_vpnaas_endpoint_group" "group_1" {
+		name = "Updated Group 1"
+		type = "cidr"
+		endpoints = ["10.2.0.0/24",
+			"10.3.0.0/24",]
+	}
+`

--- a/sbercloud/resource_sbercloud_vpnaas_ike_policy_test.go
+++ b/sbercloud/resource_sbercloud_vpnaas_ike_policy_test.go
@@ -1,0 +1,149 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/ikepolicies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccVpnIKEPolicyV2_basic(t *testing.T) {
+	var policy ikepolicies.Policy
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIKEPolicyV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIKEPolicyV2_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIKEPolicyV2Exists(
+						"sbercloud_vpnaas_ike_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "name", &policy.Name),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "description", &policy.Description),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "tenant_id", &policy.TenantID),
+				),
+			},
+			{
+				Config: testAccIKEPolicyV2_Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIKEPolicyV2Exists(
+						"sbercloud_vpnaas_ike_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "name", &policy.Name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVpnIKEPolicyV2_withLifetime(t *testing.T) {
+	var policy ikepolicies.Policy
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIKEPolicyV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIKEPolicyV2_withLifetime,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIKEPolicyV2Exists(
+						"sbercloud_vpnaas_ike_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ike_policy.policy_1", "pfs", &policy.PFS),
+				),
+			},
+			{
+				Config: testAccIKEPolicyV2_withLifetimeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIKEPolicyV2Exists(
+						"sbercloud_vpnaas_ike_policy.policy_1", &policy),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIKEPolicyV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_vpnaas_ike_policy" {
+			continue
+		}
+		_, err = ikepolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("IKE policy (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckIKEPolicyV2Exists(n string, policy *ikepolicies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+		}
+
+		found, err := ikepolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*policy = *found
+
+		return nil
+	}
+}
+
+const testAccIKEPolicyV2_basic = `
+resource "sbercloud_vpnaas_ike_policy" "policy_1" {
+}
+`
+
+const testAccIKEPolicyV2_Update = `
+resource "sbercloud_vpnaas_ike_policy" "policy_1" {
+	name = "updatedname"
+}
+`
+
+const testAccIKEPolicyV2_withLifetime = `
+resource "sbercloud_vpnaas_ike_policy" "policy_1" {
+	auth_algorithm = "sha2-256"
+	pfs = "group14"
+	lifetime {
+		units = "seconds"
+		value = 1200
+	}
+}
+`
+
+const testAccIKEPolicyV2_withLifetimeUpdate = `
+resource "sbercloud_vpnaas_ike_policy" "policy_1" {
+	auth_algorithm = "sha2-256"
+	pfs = "group14"
+	lifetime {
+		units = "seconds"
+		value = 1400
+	}
+}
+`

--- a/sbercloud/resource_sbercloud_vpnaas_ipsec_policy_test.go
+++ b/sbercloud/resource_sbercloud_vpnaas_ipsec_policy_test.go
@@ -1,0 +1,154 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/ipsecpolicies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccVpnIPSecPolicyV2_basic(t *testing.T) {
+	var policy ipsecpolicies.Policy
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIPSecPolicyV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPSecPolicyV2_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPSecPolicyV2Exists(
+						"sbercloud_vpnaas_ipsec_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "name", &policy.Name),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "description", &policy.Description),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "tenant_id", &policy.TenantID),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "pfs", &policy.PFS),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "transform_protocol", &policy.TransformProtocol),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "encapsulation_mode", &policy.EncapsulationMode),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "encryption_algorithm", &policy.EncryptionAlgorithm),
+				),
+			},
+			{
+				Config: testAccIPSecPolicyV2_Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPSecPolicyV2Exists(
+						"sbercloud_vpnaas_ipsec_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "name", &policy.Name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVpnIPSecPolicyV2_withLifetime(t *testing.T) {
+	var policy ipsecpolicies.Policy
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIPSecPolicyV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPSecPolicyV2_withLifetime,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPSecPolicyV2Exists(
+						"sbercloud_vpnaas_ipsec_policy.policy_1", &policy),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_ipsec_policy.policy_1", "pfs", &policy.PFS),
+				),
+			},
+			{
+				Config: testAccIPSecPolicyV2_withLifetimeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPSecPolicyV2Exists(
+						"sbercloud_vpnaas_ipsec_policy.policy_1", &policy),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIPSecPolicyV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_vpnaas_ipsec_policy" {
+			continue
+		}
+		_, err = ipsecpolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("IPSec policy (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckIPSecPolicyV2Exists(n string, policy *ipsecpolicies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+		}
+
+		found, err := ipsecpolicies.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*policy = *found
+
+		return nil
+	}
+}
+
+const testAccIPSecPolicyV2_basic = `
+resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+}
+`
+
+const testAccIPSecPolicyV2_Update = `
+resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+	name = "updatedname"
+}
+`
+
+const testAccIPSecPolicyV2_withLifetime = `
+resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+	auth_algorithm = "md5"
+	pfs = "group14"
+	lifetime {
+		units = "seconds"
+		value = 1200
+	}
+}
+`
+
+const testAccIPSecPolicyV2_withLifetimeUpdate = `
+resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+	auth_algorithm = "md5"
+	pfs = "group14"
+	lifetime {
+		units = "seconds"
+		value = 1400
+	}
+}
+`

--- a/sbercloud/resource_sbercloud_vpnaas_service_test.go
+++ b/sbercloud/resource_sbercloud_vpnaas_service_test.go
@@ -1,0 +1,98 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/services"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccVpnServiceV2_basic(t *testing.T) {
+	var service services.Service
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnServiceV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpnServiceV2_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpnServiceV2Exists(
+						"sbercloud_vpnaas_service.service_1", &service),
+					resource.TestCheckResourceAttrPtr("sbercloud_vpnaas_service.service_1", "router_id", &service.RouterID),
+					resource.TestCheckResourceAttr("sbercloud_vpnaas_service.service_1", "admin_state_up", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVpnServiceV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_vpnaas_service" {
+			continue
+		}
+		_, err = services.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Service (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckVpnServiceV2Exists(n string, serv *services.Service) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+		}
+
+		var found *services.Service
+
+		found, err = services.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*serv = *found
+
+		return nil
+	}
+}
+
+func testAccVpnServiceV2_basic(name string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "sbercloud_vpnaas_service" "service_1" {
+  name = "%s"
+  router_id = sbercloud_vpc.test.id
+}
+`, name, name)
+}

--- a/sbercloud/resource_sbercloud_vpnaas_site_connection_test.go
+++ b/sbercloud/resource_sbercloud_vpnaas_site_connection_test.go
@@ -1,0 +1,152 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/siteconnections"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
+	var conn siteconnections.Connection
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_vpnaas_site_connection.conn_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSiteConnectionV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteConnectionV2_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteConnectionV2Exists(resourceName, &conn),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &conn.Name),
+					resource.TestCheckResourceAttrPtr(resourceName, "vpnservice_id", &conn.VPNServiceID),
+					resource.TestCheckResourceAttrPtr(resourceName, "ikepolicy_id", &conn.IKEPolicyID),
+					resource.TestCheckResourceAttrPtr(resourceName, "ipsecpolicy_id", &conn.IPSecPolicyID),
+					resource.TestCheckResourceAttrPtr(resourceName, "peer_ep_group_id", &conn.PeerEPGroupID),
+					resource.TestCheckResourceAttrPtr(resourceName, "local_ep_group_id", &conn.LocalEPGroupID),
+					resource.TestCheckResourceAttrPtr(resourceName, "local_id", &conn.LocalID),
+
+					resource.TestCheckResourceAttr(resourceName, "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSiteConnectionV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_vpnaas_site_connection" {
+			continue
+		}
+		_, err = siteconnections.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Site connection (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckSiteConnectionV2Exists(n string, conn *siteconnections.Connection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		networkingClient, err := config.NetworkingV2Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating SberCloud networking client: %s", err)
+		}
+
+		var found *siteconnections.Connection
+
+		found, err = siteconnections.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*conn = *found
+
+		return nil
+	}
+}
+
+func testAccSiteConnectionV2_basic(name string) string {
+	return fmt.Sprintf(`
+	resource "sbercloud_vpc" "test" {
+		name = "%s"
+		cidr = "192.168.0.0/16"
+}
+
+	resource "sbercloud_vpc_subnet" "test" {
+		name          = "%s"
+		cidr          = "192.168.0.0/24"
+		gateway_ip    = "192.168.0.1"
+		primary_dns   = "100.125.1.250"
+		secondary_dns = "100.125.21.250"
+		vpc_id        = sbercloud_vpc.test.id
+	}
+
+	resource "sbercloud_vpnaas_service" "service_1" {
+		name = "%s"
+		router_id = sbercloud_vpc.test.id
+	}
+
+	resource "sbercloud_vpnaas_ipsec_policy" "policy_1" {
+	}
+
+	resource "sbercloud_vpnaas_ike_policy" "policy_2" {
+	}
+
+	resource "sbercloud_vpnaas_endpoint_group" "group_1" {
+		type = "cidr"
+		endpoints = ["10.2.0.0/24", "10.3.0.0/24"]
+	}
+
+	resource "sbercloud_vpnaas_endpoint_group" "group_2" {
+		type = "cidr"
+		endpoints = [sbercloud_vpc_subnet.test.cidr]
+	}
+
+	resource "sbercloud_vpnaas_site_connection" "conn_1" {
+		name = "%s"
+		ikepolicy_id = sbercloud_vpnaas_ike_policy.policy_2.id
+		ipsecpolicy_id = sbercloud_vpnaas_ipsec_policy.policy_1.id
+		vpnservice_id = sbercloud_vpnaas_service.service_1.id
+		psk = "secret"
+		peer_address = "192.168.10.1"
+		peer_id = "192.168.10.1"
+		local_ep_group_id = sbercloud_vpnaas_endpoint_group.group_2.id
+		peer_ep_group_id = sbercloud_vpnaas_endpoint_group.group_1.id
+
+		tags = {
+			foo = "bar"
+			key = "value"
+		}
+
+		depends_on = ["sbercloud_vpc_subnet.test"]
+	}
+	`, name, name, name, name)
+}


### PR DESCRIPTION
This PR adds 5 objects

**Resources**
sbercloud_vpnaas_endpoint_group
sbercloud_vpnaas_ike_policy
sbercloud_vpnaas_ipsec_policy
sbercloud_vpnaas_service
sbercloud_vpnaas_site_connection

This closes #76 

All acceptance tests are done:
```
make testacc TEST='./sbercloud' TESTARGS='-run TestAccVpn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccVpn -timeout 360m -parallel=4
=== RUN   TestAccVpnGroupV2_basic
=== PAUSE TestAccVpnGroupV2_basic
=== RUN   TestAccVpnIKEPolicyV2_basic
=== PAUSE TestAccVpnIKEPolicyV2_basic
=== RUN   TestAccVpnIKEPolicyV2_withLifetime
=== PAUSE TestAccVpnIKEPolicyV2_withLifetime
=== RUN   TestAccVpnIPSecPolicyV2_basic
=== PAUSE TestAccVpnIPSecPolicyV2_basic
=== RUN   TestAccVpnIPSecPolicyV2_withLifetime
=== PAUSE TestAccVpnIPSecPolicyV2_withLifetime
=== RUN   TestAccVpnServiceV2_basic
=== PAUSE TestAccVpnServiceV2_basic
=== RUN   TestAccVpnSiteConnectionV2_basic
=== PAUSE TestAccVpnSiteConnectionV2_basic
=== CONT  TestAccVpnGroupV2_basic
=== CONT  TestAccVpnIPSecPolicyV2_withLifetime
=== CONT  TestAccVpnIKEPolicyV2_withLifetime
=== CONT  TestAccVpnIPSecPolicyV2_basic
--- PASS: TestAccVpnIPSecPolicyV2_withLifetime (15.83s)
=== CONT  TestAccVpnSiteConnectionV2_basic
--- PASS: TestAccVpnIPSecPolicyV2_basic (15.98s)
=== CONT  TestAccVpnServiceV2_basic
--- PASS: TestAccVpnIKEPolicyV2_withLifetime (16.18s)
=== CONT  TestAccVpnIKEPolicyV2_basic
--- PASS: TestAccVpnGroupV2_basic (16.43s)
--- PASS: TestAccVpnIKEPolicyV2_basic (15.20s)
--- PASS: TestAccVpnServiceV2_basic (33.81s)
--- PASS: TestAccVpnSiteConnectionV2_basic (69.78s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   86.026s
```