### PR TITLE
feat(EPS): add new objects

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# sbercloud_enterprise_project
+
+Use this data source to get an enterprise project from SberCloud
+
+## Example Usage
+
+```hcl
+data "sbercloud_enterprise_project" "test" {
+  name = "test"
+}
+```
+
+## Resources Supported Currently
+
+<!-- markdownlint-disable MD033 -->
+Service Name | Resource Name | Sub Resource Name
+---- | --- | ---
+AS  | sbercloud_as_group |
+CBR | sbercloud_cbr_vault |
+CCE | sbercloud_cce_cluster | sbercloud_cce_node<br>sbercloud_cce_node_pool
+CDM | sbercloud_cdm_cluster |
+CES | sbercloud_ces_alarmrule |
+DCS | sbercloud_dcs_instance |
+DDS | sbercloud_dds_instance |
+DMS | sbercloud_dms_kafka_instance<br>sbercloud_dms_rabbitmq_instance |
+DNS | sbercloud_dns_ptrrecord<br>sbercloud_dns_zone |
+ECS | sbercloud_compute_instance |
+EIP | sbercloud_vpc_eip<br>sbercloud_vpc_bandwidth |
+ELB | sbercloud_lb_loadbalancer |
+EVS | sbercloud_evs_volume |
+FGS | sbercloud_fgs_function |
+IMS | sbercloud_images_image |
+NAT | sbercloud_nat_gateway | sbercloud_nat_snat_rule<br>sbercloud_nat_dnat_rule
+OBS | sbercloud_obs_bucket | sbercloud_obs_bucket_object<br>sbercloud_obs_bucket_policy
+RDS | sbercloud_rds_instance<br>sbercloud_rds_read_replica_instance |
+SFS | sbercloud_sfs_file_system<br>sbercloud_sfs_turbo | sbercloud_sfs_access_rule
+VPC | sbercloud_vpc<br>sbercloud_networking_secgroup | sbercloud_vpc_subnet<br>sbercloud_vpc_route<br>sbercloud_networking_secgroup_rule
+<!-- markdownlint-enable MD033 -->
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the enterprise project name. Fuzzy search is supported.
+
+* `id` - (Optional, String) Specifies the ID of an enterprise project. The value 0 indicates enterprise project default.
+
+* `status` - (Optional, Int) Specifies the status of an enterprise project.
+    + 1 indicates Enabled.
+    + 2 indicates Disabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - Provides supplementary information about the enterprise project.
+
+* `created_at` - Specifies the time (UTC) when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Specifies the time (UTC) when the enterprise project was modified. Example: 2018-05-28T02:21:36Z

--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# sbercloud_enterprise_project
+
+Use this resource to manage an enterprise project within SberCloud.
+
+-> **NOTE:** Deleting enterprise projects is not support. If you destroy a resource of enterprise project,
+  the project is only disabled and removed from the state, but it remains in the cloud
+
+## Example Usage
+
+```hcl
+resource "sbercloud_enterprise_project" "test" {
+  name        = "test"
+  description = "example project"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the name of the enterprise project.
+  This parameter can contain 1 to 64 characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
+  The name must be unique in the domain and cannot include any form of the word "default" ("deFaulT", for instance).
+
+* `description` - (Optional, String) Specifies the description of the enterprise project.
+
+* `type` - (Optional, String) Specifies the type of the enterprise project.
+  The valid values are *poc* and *prod*, default to *prod*.
+
+* `enable` - (Optional, Bool) Specifies whether to enable the enterprise project. Default to *true*.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - Indicates the status of an enterprise project.
+  + 1 indicates Enabled.
+  + 2 indicates Disabled.
+
+* `created_at` - Indicates the time (UTC) when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Indicates the time (UTC) when the enterprise project was modified. Example: 2018-05-28T02:21:36Z
+
+## Import
+
+Enterprise projects can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_enterprise_project.test 88f889c7-270e-4e77-8230-bf7db08d9b0e
+```
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 5 minute.

--- a/sbercloud/eps/data_source_sbercloud_enterprise_project_test.go
+++ b/sbercloud/eps/data_source_sbercloud_enterprise_project_test.go
@@ -1,0 +1,35 @@
+package eps
+
+import (
+	"testing"
+
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEnterpriseProjectDataSource_basic(t *testing.T) {
+	dataSourceName := "data.sbercloud_enterprise_project.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProjectDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "default"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEnterpriseProjectDataSource_basic = `
+data "sbercloud_enterprise_project" "test" {
+  name = "default"
+}
+`

--- a/sbercloud/eps/resource_sbercloud_enterprise_project_test.go
+++ b/sbercloud/eps/resource_sbercloud_enterprise_project_test.go
@@ -1,0 +1,109 @@
+package eps
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+)
+
+func getResourceEnterpriseProject(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	epsClient, err := config.EnterpriseProjectClient(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("Unable to create SberCloud EPS client : %s", err)
+	}
+
+	return enterpriseprojects.Get(epsClient, state.Primary.ID).Extract()
+
+}
+
+func TestAccEnterpriseProject_basic(t *testing.T) {
+	var project enterpriseprojects.Project
+	rName := acceptance.RandomAccResourceName()
+	updateName := rName + "update"
+	resourceName := "sbercloud_enterprise_project.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&project,
+		getResourceEnterpriseProject,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEnterpriseProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProject_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				Config: testAccEnterpriseProject_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnterpriseProjectDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	epsClient, err := config.EnterpriseProjectClient(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Unable to create SberCloud EPS client : %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_enterprise_project" {
+			continue
+		}
+
+		project, err := enterpriseprojects.Get(epsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			if project.Status != 2 {
+				return fmtp.Errorf("Project still active")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccEnterpriseProject_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test"
+}`, rName)
+}
+
+func testAccEnterpriseProject_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test update"
+}`, rName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/evs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
@@ -135,6 +136,7 @@ func Provider() *schema.Provider {
 			"sbercloud_dms_az":                 deprecated.DataSourceDmsAZ(),
 			"sbercloud_dms_product":            dms.DataSourceDmsProduct(),
 			"sbercloud_dms_maintainwindow":     dms.DataSourceDmsMaintainWindow(),
+			"sbercloud_enterprise_project":     eps.DataSourceEnterpriseProject(),
 			"sbercloud_identity_role":          iam.DataSourceIdentityRoleV3(),
 			"sbercloud_identity_custom_role":   iam.DataSourceIdentityCustomRole(),
 			"sbercloud_identity_group":         iam.DataSourceIdentityGroup(),
@@ -191,6 +193,7 @@ func Provider() *schema.Provider {
 			"sbercloud_dns_recordset":                   huaweicloud.ResourceDNSRecordSetV2(),
 			"sbercloud_dns_zone":                        huaweicloud.ResourceDNSZoneV2(),
 			"sbercloud_dws_cluster":                     dws.ResourceDwsCluster(),
+			"sbercloud_enterprise_project":              eps.ResourceEnterpriseProject(),
 			"sbercloud_evs_snapshot":                    huaweicloud.ResourceEvsSnapshotV2(),
 			"sbercloud_evs_volume":                      evs.ResourceEvsVolume(),
 			"sbercloud_fgs_function":                    fgs.ResourceFgsFunctionV2(),


### PR DESCRIPTION
This PR adds 2 objects:

**Data Sources**
sbercloud_enterprise_project

**Resources**
sbercloud_enterprise_project

This closes #119 

All EPS acceptance tests are done:
```
make testacc TEST='./sbercloud/eps' TESTARGS='-run TestAccEnterpriseProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/eps -v -run TestAccEnterpriseProject -timeout 360m -parallel=4
=== RUN   TestAccEnterpriseProjectDataSource_basic
=== PAUSE TestAccEnterpriseProjectDataSource_basic
=== RUN   TestAccEnterpriseProject_basic
=== PAUSE TestAccEnterpriseProject_basic
=== CONT  TestAccEnterpriseProjectDataSource_basic
=== CONT  TestAccEnterpriseProject_basic
--- PASS: TestAccEnterpriseProjectDataSource_basic (7.40s)
--- PASS: TestAccEnterpriseProject_basic (15.46s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/eps       15.745s
```