### PR TITLE
feat(CBR): add new objects

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# sbercloud_cbr_vaults
+
+Use this data source to get available CBR vaults within Sbercloud.
+
+## Example Usage
+
+### Get vaults for all server type
+
+```hcl
+data "sbercloud_cbr_vaults" "test" {
+  type = "server"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `consistent_level` - (Optional, String) Specifies the backup specifications.
+  The value is crash_consistent by default (crash consistent backup).
+
+  Only server type vaults support application consistent.
+
+* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+  The valid value is **backup**.
+
+* `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
+  type vault. Default to **false**.
+
+* `enterprise_project_id` - (Optional, String) Specifies a unique ID in UUID format of enterprise project.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+
+* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in hashcode format.
+
+* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+
+The `vaults` block supports:
+
+* `id` - The vault ID in UUID format.
+
+* `name` - The CBR vault name.
+
+* `type` - The object type of the CBR vault.
+
+* `consistent_level` - The backup specifications.
+
+* `protection_type` - The protection type of the CBR vault.
+
+* `size` - The vault capacity, in GB.
+
+* `auto_expand_enabled` - Whether to enable automatic expansion of the backup protection type vault.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `policy_id` - The policy associated with the CBR vault.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+* `resources` - An array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+The `resources` block supports:
+
+* `server_id` - The ID of the ECS instance to be backed up.
+
+* `includes` - An array of disk or SFS file system IDs which will be included in the backup.

--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# sbercloud_cbr_policy
+
+Manages a CBR Policy resource within Sbercloud.
+
+## Example Usage
+
+### create a backup policy
+
+```hcl
+variable "policy_name" {}
+
+resource "sbercloud_cbr_policy" "test" {
+  name        = var.policy_name
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    frequency       = "WEEKLY"
+    days            = "MO,TH"
+    execution_times = ["06:00"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR policy. If omitted, the
+  provider-level region will be used. Changing this will create a new policy.
+
+* `name` - (Required, String) Specifies a unique name of the CBR policy. This parameter can contain a maximum of 64
+  characters, which may consist of chinese charactors, letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the protection type of the CBR policy.
+  Valid value is **backup**.
+  Changing this will create a new policy.
+
+* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution.
+  The [object](#cbr_policy_backup_cycle) structure is documented below.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to **true**.
+
+* `backup_quantity` - (Optional, Int) Specifies the maximum number of retained backups. The value ranges from `2` to
+  `99,999`. This parameter and `time_period` are alternative.
+
+* `time_period` - (Optional, Int) Specifies the duration (in days) for retained backups. The value ranges from `2` to
+  `99,999`.
+
+-> **NOTE:** If this `backup_quantity` and `time_period` are both left blank, the backups will be retained permanently.
+
+<a name="cbr_policy_backup_cycle"></a>
+The `backup_cycle` block supports:
+
+* `days` - (Optional, String) Specifies the weekly backup day of backup schedule. It supports seven days a week (MO, TU,
+  WE, TH, FR, SA, SU) and this parameter is separated by a comma (,) without spaces, between date and date during the
+  configuration.
+
+* `interval` - (Optional, Int) Specifies the interval (in days) of backup schedule. The value range is `1` to `30`. This
+  parameter and `days` are alternative.
+
+* `execution_times` - (Required, List) Specifies the backup time. Automated backups will be triggered at the backup
+  time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to **00** and the hours
+  cannot be repeated.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+## Import
+
+Policies can be imported by their `id`. For example,
+
+```
+terraform import sbercloud_cbr_policy.test 4d2c2939-774f-42ef-ab15-e5b126b11ace
+```

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -1,0 +1,146 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# sbercloud_cbr_vault
+
+Manages a CBR Vault resource within Sbercloud.
+
+## Example Usage
+
+### Create a server type vault
+
+```hcl
+variable "vault_name" {}
+variable "ecs_instance_id" {}
+variable "evs_volume_id" {}
+
+data "sbercloud_compute_instance" "test" {
+  ...
+}
+
+resource "sbercloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "server"
+  protection_type  = "backup"
+  consistent_level = "crash_consistent"
+  size             = 100
+
+  resources {
+    server_id = var.ecs_instance_id
+  }
+}
+```
+
+### Create a disk type vault
+
+```hcl
+variable "vault_name" {}
+variable "evs_volume_id" {}
+
+resource "sbercloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "disk"
+  protection_type  = "backup"
+  consistent_level = "crash_consistent"
+  size             = 50
+  auto_expand      = true
+
+  resources {
+    includes = [
+      var.evs_volume_id
+    ]
+  }
+}
+```
+
+### Create an SFS turbo type vault
+
+```hcl
+variable "vault_name" {}
+variable "sfs_turbo_id" {}
+
+resource "sbercloud_cbr_vault" "test" {
+  name             = var.vault_name
+  consistent_level = "crash_consistent"
+  type             = "turbo"
+  protection_type  = "backup"
+  size             = 1000
+
+  resources {
+    includes = [
+      var.sfs_turbo_id
+    ]
+  }
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR vault. If omitted, the
+  provider-level region will be used. Changing this will create a new vault.
+
+* `name` - (Required, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the object type of the CBR vault.
+  Changing this will create a new vault. Vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `consistent_level` - (Required, String, ForceNew) Specifies the backup specifications.
+  The value is crash_consistent by default (crash consistent backup).
+
+* `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
+  The valid value is **backup**.
+  Changing this will create a new vault.
+
+* `size` - (Required, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
+  Default to **false**.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
+  Changing this will create a new vault.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+
+* `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBR vault.
+
+<a name="cbr_vault_resources"></a>
+The `resources` block supports:
+
+* `server_id` - (Optional, String) Specifies the ID of the ECS instance to be backed up.
+
+* `includes` - (Optional, List) Specifies the array of disk or SFS file system IDs which will be included in the backup.
+  Only **disk** and **turbo** vault support this parameter.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+## Import
+
+Vaults can be imported by their `id`. For example,
+
+```
+$ terraform import sbercloud_cbr_vault.test 01c33779-7c83-4182-8b6b-24a671fcedf8
+```

--- a/sbercloud/cbr/data_source_sbercloud_cbr_vaults_test.go
+++ b/sbercloud/cbr/data_source_sbercloud_cbr_vaults_test.go
@@ -1,0 +1,183 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "sbercloud_cbr_vault.test"
+	dataSourceName := "data.sbercloud_cbr_vaults.test"
+
+	var vault vaults.Vault
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccCbrVaultsV3_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "sbercloud_cbr_vault.test"
+	dataSourceName := "data.sbercloud_cbr_vaults.test"
+
+	var vault vaults.Vault
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccCbrVaultsV3_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "50"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "sbercloud_cbr_vault.test"
+	dataSourceName := "data.sbercloud_cbr_vaults.test"
+
+	var vault vaults.Vault
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccCbrVaultsV3_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "800"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCbrVaultsV3_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cbr_vaults" "test" {
+  name = sbercloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_serverBasic(rName))
+}
+
+func testAccCbrVaultsV3_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cbr_vaults" "test" {
+  name = sbercloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_volumeBasic(rName))
+}
+
+func testAccCbrVaultsV3_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cbr_vaults" "test" {
+  name = sbercloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_turboBasic(rName))
+}

--- a/sbercloud/cbr/resource_sbercloud_cbr_policy_test.go
+++ b/sbercloud/cbr/resource_sbercloud_cbr_policy_test.go
@@ -1,0 +1,101 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CbrV3Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SberCloud CBR client: %s", err)
+	}
+	return policies.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccCBRV3Policy_basic(t *testing.T) {
+	var asPolicy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_cbr_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "MO,TU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "18:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "5"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCBRV3Policy_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_cbr_policy" "test" {
+  name            = "%s-update"
+  type            = "backup"
+  backup_quantity = 5
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}

--- a/sbercloud/cbr/resource_sbercloud_cbr_vault_test.go
+++ b/sbercloud/cbr/resource_sbercloud_cbr_vault_test.go
@@ -1,0 +1,473 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func getVaultResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CbrV3Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SberCloud CBR client: %s", err)
+	}
+	return vaults.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccCBRV3Vault_BasicServer(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_serverUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "300"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "policy_id",
+						"${sbercloud_cbr_policy.test.id}"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_volumeUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "800"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_turboUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCBRV3Vault_policy(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testAccCBRV3VaultBasicConfiguration(rName string) string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    volume_type = string
+    size        = number
+    device_type = string
+  }))
+  default = [
+    {volume_type = "SSD", size = 100, device_type = "VBD"},
+    {volume_type = "SSD", size = 100, device_type = "SCSI"},
+  ]
+}
+
+data "sbercloud_availability_zones" "test" {}
+
+data "sbercloud_compute_flavors" "test" {
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "sbercloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "sbercloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = sbercloud_vpc.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "sbercloud_networking_secgroup" "test" {
+  name                 = "%s"
+  delete_default_rules = true
+}
+
+resource "sbercloud_compute_keypair" "test" {
+  name = "%s"
+  lifecycle {
+    ignore_changes = [
+      public_key,
+    ]
+  }
+}
+
+resource "sbercloud_compute_instance" "test" {
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  name              = "%s"
+  image_id          = data.sbercloud_images_image.test.id
+  flavor_id         = data.sbercloud_compute_flavors.test.ids[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+
+  system_disk_type = "SSD"
+  system_disk_size = 50
+
+  security_group_ids = [
+    sbercloud_networking_secgroup.test.id
+  ]
+
+  network {
+    uuid = sbercloud_vpc_subnet.test.id
+  }
+}
+
+resource "sbercloud_evs_volume" "test" {
+  count = length(var.volume_configuration)
+
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  volume_type       = var.volume_configuration[count.index].volume_type
+  name              = "%s_${tostring(count.index)}"
+  size              = var.volume_configuration[count.index].size
+  device_type       = var.volume_configuration[count.index].device_type
+}
+
+resource "sbercloud_compute_volume_attach" "test" {
+  count = length(sbercloud_evs_volume.test)
+
+  instance_id = sbercloud_compute_instance.test.id
+  volume_id   = sbercloud_evs_volume.test[count.index].id
+}`, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s"
+  type                  = "server"
+  consistent_level      = "app_consistent"
+  protection_type       = "backup"
+  size                  = 200
+  enterprise_project_id = "%s"
+
+  resources {
+    server_id = sbercloud_compute_instance.test.id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(rName),
+		rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}
+
+func testAccCBRV3Vault_serverUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  type                  = "server"
+  consistent_level      = "app_consistent"
+  protection_type       = "backup"
+  size                  = 300
+  enterprise_project_id = "%s"
+  policy_id             = sbercloud_cbr_policy.test.id
+
+  resources {
+    server_id = sbercloud_compute_instance.test.id
+ }
+}
+`, testAccCBRV3VaultBasicConfiguration(rName), testAccCBRV3Vault_policy(rName),
+		rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}
+
+func testAccCBRV3Vault_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s"
+  consistent_level      = "crash_consistent"
+  type                  = "disk"
+  protection_type       = "backup"
+  size                  = 50
+  enterprise_project_id = "%s"
+
+  resources {
+    includes = sbercloud_compute_volume_attach.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(rName),
+		rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}
+
+func testAccCBRV3Vault_volumeUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  consistent_level      = "crash_consistent"
+  type                  = "disk"
+  protection_type       = "backup"
+  size                  = 100
+  auto_expand           = true
+  enterprise_project_id = "%s"
+  policy_id             = sbercloud_cbr_policy.test.id
+
+  resources {
+    includes = sbercloud_compute_volume_attach.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(rName),
+		testAccCBRV3Vault_policy(rName), rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}
+
+//Vaults of type 'turbo'
+func testAccCBRV3Vault_turboBase(rName string) string {
+	return fmt.Sprintf(`
+data "sbercloud_availability_zones" "test" {}
+
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "sbercloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/22"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = sbercloud_vpc.test.id
+}
+
+resource "sbercloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "sbercloud_sfs_turbo" "test1" {
+  name              = "%s-1"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = sbercloud_vpc.test.id
+  subnet_id         = sbercloud_vpc_subnet.test.id
+  security_group_id = sbercloud_networking_secgroup.test.id
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+}`, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s"
+  consistent_level      = "crash_consistent"
+  type                  = "turbo"
+  protection_type       = "backup"
+  size                  = 800
+  enterprise_project_id = "%s"
+
+  resources {
+    includes = [
+      sbercloud_sfs_turbo.test1.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}
+
+func testAccCBRV3Vault_turboUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "sbercloud_sfs_turbo" "test2" {
+  name              = "%s-2"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = sbercloud_vpc.test.id
+  subnet_id         = sbercloud_vpc_subnet.test.id
+  security_group_id = sbercloud_networking_secgroup.test.id
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+}
+
+resource "sbercloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  consistent_level      = "crash_consistent"
+  type                  = "turbo"
+  protection_type       = "backup"
+  size                  = 1000
+  enterprise_project_id = "%s"
+  policy_id             = sbercloud_cbr_policy.test.id
+
+  resources {
+    includes = [
+      sbercloud_sfs_turbo.test1.id,
+      sbercloud_sfs_turbo.test2.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), testAccCBRV3Vault_policy(rName), rName, rName,
+		acceptance.SBC_ENTERPRISE_PROJECT_ID)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/css"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dcs"
@@ -123,6 +124,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"sbercloud_availability_zones":     huaweicloud.DataSourceAvailabilityZones(),
+			"sbercloud_cbr_vaults":             cbr.DataSourceCbrVaultsV3(),
 			"sbercloud_cce_cluster":            huaweicloud.DataSourceCCEClusterV3(),
 			"sbercloud_cce_node":               huaweicloud.DataSourceCCENodeV3(),
 			"sbercloud_cce_node_pool":          huaweicloud.DataSourceCCENodePoolV3(),
@@ -168,6 +170,8 @@ func Provider() *schema.Provider {
 			"sbercloud_as_configuration":                huaweicloud.ResourceASConfiguration(),
 			"sbercloud_as_group":                        huaweicloud.ResourceASGroup(),
 			"sbercloud_as_policy":                       huaweicloud.ResourceASPolicy(),
+			"sbercloud_cbr_policy":                      cbr.ResourceCBRPolicyV3(),
+			"sbercloud_cbr_vault":                       cbr.ResourceCBRVaultV3(),
 			"sbercloud_css_cluster":                     css.ResourceCssCluster(),
 			"sbercloud_cce_cluster":                     huaweicloud.ResourceCCEClusterV3(),
 			"sbercloud_cce_node":                        huaweicloud.ResourceCCENodeV3(),


### PR DESCRIPTION
This PR adds 3 objects:

**Data Sources**
sbercloud_cbr_vaults

**Resources**
sbercloud_cbr_policy
sbercloud_cbr_vault

This closes #117 

All CBR acceptance tests are done well:
```
make testacc TEST='./sbercloud/cbr' TESTARGS='-run TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/cbr -v -run TestAcc -timeout 360m -parallel=4
=== RUN   TestAccCbrVaultsV3_BasicServer
=== PAUSE TestAccCbrVaultsV3_BasicServer
=== RUN   TestAccCbrVaultsV3_BasicVolume
=== PAUSE TestAccCbrVaultsV3_BasicVolume
=== RUN   TestAccCbrVaultsV3_BasicTurbo
=== PAUSE TestAccCbrVaultsV3_BasicTurbo
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== RUN   TestAccCBRV3Vault_BasicServer
=== PAUSE TestAccCBRV3Vault_BasicServer
=== RUN   TestAccCBRV3Vault_BasicVolume
=== PAUSE TestAccCBRV3Vault_BasicVolume
=== RUN   TestAccCBRV3Vault_BasicTurbo
=== PAUSE TestAccCBRV3Vault_BasicTurbo
=== CONT  TestAccCbrVaultsV3_BasicServer
=== CONT  TestAccCBRV3Vault_BasicServer
=== CONT  TestAccCbrVaultsV3_BasicTurbo
=== CONT  TestAccCbrVaultsV3_BasicVolume
--- PASS: TestAccCBRV3Vault_BasicServer (265.41s)
=== CONT  TestAccCBRV3Policy_basic
--- PASS: TestAccCbrVaultsV3_BasicServer (271.93s)
=== CONT  TestAccCBRV3Vault_BasicTurbo
--- PASS: TestAccCbrVaultsV3_BasicVolume (273.57s)
=== CONT  TestAccCBRV3Vault_BasicVolume
--- PASS: TestAccCBRV3Policy_basic (16.29s)
--- PASS: TestAccCbrVaultsV3_BasicTurbo (297.76s)
--- PASS: TestAccCBRV3Vault_BasicVolume (264.43s)
--- PASS: TestAccCBRV3Vault_BasicTurbo (518.59s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/cbr       790.868s
```