### PR TITLE
fix(VPC): update vpc route resource

### DIFF
--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -238,7 +238,7 @@ func Provider() *schema.Provider {
 			"sbercloud_vpc_eip":                         eip.ResourceVpcEIPV1(),
 			"sbercloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"sbercloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
-			"sbercloud_vpc_route":                       vpc.ResourceVPCRouteV2(),
+			"sbercloud_vpc_route":                       vpc.ResourceVPCRouteTableRoute(),
 			"sbercloud_vpc_route_table":                 vpc.ResourceVPCRouteTable(),
 			"sbercloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
 			// Legacy


### PR DESCRIPTION
This PR fixes `sbercloud_vpc_route` resource version with tests.

Related acceptance test is done successfully:
```
make testacc TEST='./sbercloud/vpc' TESTARGS='-run TestAccVpcRTBRoute'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/vpc -v -run TestAccVpcRTBRoute -timeout 360m -parallel=4
=== RUN   TestAccVpcRTBRoute_basic
=== PAUSE TestAccVpcRTBRoute_basic
=== CONT  TestAccVpcRTBRoute_basic
--- PASS: TestAccVpcRTBRoute_basic (41.62s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/vpc       41.966s
```