### PR TITLE
feat(IAM): add identity_project resource

### DIFF
--- a/docs/resources/identity_project.md
+++ b/docs/resources/identity_project.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# sbercloud_identity_project
+
+Manages a Project resource within SberCloud Identity And Access Management service.
+
+-> You *must* have security admin privileges in your SberCloud cloud to use this resource.
+
+!>  Deleting projects is not supported. The project is only removed from the state, but it remains in the cloud.
+
+## Example Usage
+
+```hcl
+resource "sbercloud_identity_project" "project_1" {
+  name        = "ru-moscow-1_project1"
+  description = "This is a test project"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the name of the project. it must start with an existing *region* and be less
+  than or equal to 64 characters. Example: ru-moscow-1_project1.
+
+* `description` - (Optional, String) Specifies the description of the project.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+* `parent_id` - The parent of this project.
+
+* `enabled` - Enabling status of this project.
+
+## Import
+
+Projects can be imported using the `id`, e.g.
+
+```
+$ terraform import sbercloud_identity_project.project_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```

--- a/sbercloud/iam/resource_sbercloud_identity_project_test.go
+++ b/sbercloud/iam/resource_sbercloud_identity_project_test.go
@@ -1,0 +1,90 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3/projects"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getIdentityProjectResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.IdentityV3Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("Error creating SberCloud IAM client: %s", err)
+	}
+	return projects.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccIdentityV3Project_basic(t *testing.T) {
+	var project projects.Project
+	var projectName = acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_identity_project.project_1"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&project,
+		getIdentityProjectResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckProject(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceExists(), // deleting projects is not supported.
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3Project_basic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &project.Name),
+					resource.TestCheckResourceAttr(resourceName, "description", "A project"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "parent_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIdentityV3Project_update(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &project.Name),
+					resource.TestCheckResourceAttr(resourceName, "description", "An updated project"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "parent_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityV3Project_basic(projectName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_identity_project" "project_1" {
+  name        = "%s_%s"
+  description = "A project"
+}
+`, acceptance.SBC_REGION_NAME, projectName)
+}
+
+func testAccIdentityV3Project_update(projectName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_identity_project" "project_1" {
+  name        = "%s_%s"
+  description = "An updated project"
+}
+`, acceptance.SBC_REGION_NAME, projectName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -200,6 +200,7 @@ func Provider() *schema.Provider {
 			"sbercloud_identity_agency":                 iam.ResourceIAMAgencyV3(),
 			"sbercloud_identity_group":                  iam.ResourceIdentityGroupV3(),
 			"sbercloud_identity_group_membership":       iam.ResourceIdentityGroupMembershipV3(),
+			"sbercloud_identity_project":                iam.ResourceIdentityProjectV3(),
 			"sbercloud_identity_role":                   iam.ResourceIdentityRole(),
 			"sbercloud_identity_role_assignment":        iam.ResourceIdentityRoleAssignmentV3(),
 			"sbercloud_identity_user":                   iam.ResourceIdentityUserV3(),


### PR DESCRIPTION
This PR adds `sbercloud_identity_project` resource.

This closes #105 

Related acceptance test is completely done:
```
make testacc TEST='./sbercloud/iam' TESTARGS='-run TestAccIdentityV3Project_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/iam -v -run TestAccIdentityV3Project_basic -timeout 360m -parallel=4
=== RUN   TestAccIdentityV3Project_basic
=== PAUSE TestAccIdentityV3Project_basic
=== CONT  TestAccIdentityV3Project_basic
--- PASS: TestAccIdentityV3Project_basic (12.77s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/iam       13.132s
```