### PR TITLE
fix(doc): update disk_type from `SATA` to `SSD` for some examples

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -18,7 +18,7 @@ resource "sbercloud_as_configuration" "my_as_config" {
     image  = var.image_id
     disk {
       size        = 40
-      volume_type = "SATA"
+      volume_type = "SSD"
       disk_type   = "SYS"
     }
     key_name  = var.keyname
@@ -37,12 +37,12 @@ resource "sbercloud_as_configuration" "my_as_config" {
     image  = var.image_id
     disk {
       size        = 40
-      volume_type = "SATA"
+      volume_type = "SSD"
       disk_type   = "SYS"
     }
     disk {
       size        = 100
-      volume_type = "SATA"
+      volume_type = "SSD"
       disk_type   = "DATA"
       kms_id      = var.kms_id
     }
@@ -62,7 +62,7 @@ resource "sbercloud_as_configuration" "my_as_config" {
     image  = var.image_id
     disk {
       size        = 40
-      volume_type = "SATA"
+      volume_type = "SSD"
       disk_type   = "SYS"
     }
     key_name  = var.keyname

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -34,11 +34,11 @@ resource "sbercloud_cce_node" "node" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
 }
 ```
@@ -55,11 +55,11 @@ resource "sbercloud_cce_node" "mynode" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
 
   // Assign EIP
@@ -94,11 +94,11 @@ resource "sbercloud_cce_node" "mynode" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SSD"
   }
 
   // Assign existing EIP

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -124,7 +124,7 @@ resource "sbercloud_compute_instance" "multi-disk" {
   system_disk_size = 40
 
   data_disks {
-    type = "SATA"
+    type = "SSD"
     size = "10"
   }
   data_disks {

--- a/docs/resources/evs_snapshot.md
+++ b/docs/resources/evs_snapshot.md
@@ -12,7 +12,7 @@ Provides an EVS snapshot resource.
 resource "sbercloud_evs_volume" "myvolume" {
   name        = "volume"
   description = "my volume"
-  volume_type = "SATA"
+  volume_type = "SSD"
   size        = 20
 
   availability_zone = "ru-moscow-1a"

--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -12,7 +12,7 @@ Manages a volume resource within sbercloud.
 resource "sbercloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
-  volume_type       = "SATA"
+  volume_type       = "SSD"
   size              = 20
   availability_zone = "ru-moscow-1a"
 }
@@ -24,7 +24,7 @@ resource "sbercloud_evs_volume" "volume" {
 resource "sbercloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
-  volume_type       = "SATA"
+  volume_type       = "SSD"
   size              = 20
   kms_id            = var.kms_id
   availability_zone = "ru-moscow-1a"


### PR DESCRIPTION
This PR changes unsupported `SATA` on `SSD` disk type for some examples.

This closes #97 