### PR TITLE
feat(CCE): add addon objects

### DIFF
--- a/docs/data-sources/cce_addon_template.md
+++ b/docs/data-sources/cce_addon_template.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_addon_template
+
+Use this data source to get available SberCloud CCE add-on template.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+variable "addon_name" {}
+
+variable "addon_version" {}
+
+data "sbercloud_cce_addon_template" "test" {
+  cluster_id = var.cluster_id
+  name       = var.addon_name
+  version    = var.addon_version
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CCE add-ons. If omitted, the provider-level
+  region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of container cluster.
+
+* `name` - (Required, String) Specifies the add-on name.
+
+* `version` - (Required, String) Specifies the add-on version.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of the add-on template.
+
+* `description` - The description of the add-on.
+
+* `spec` - The detail configuration of the add-on template.
+
+* `stable` - Whether the add-on template is a stable version.
+
+* `support_version/virtual_machine` - The cluster (Virtual Machine) version that the add-on template supported.
+
+* `support_version/bare_metal` - The cluster (Bare Metal) version that the add-on template supported.

--- a/docs/resources/cce_addon.md
+++ b/docs/resources/cce_addon.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_addon
+
+Provides a CCE add-on resource within SberCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "sbercloud_cce_addon" "addon_test" {
+  cluster_id    = var.cluster_id
+  template_name = "metrics-server"
+  version       = "1.1.10"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CCE add-on resource.
+  If omitted, the provider-level region will be used. Changing this creates a new CCE add-on resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID.
+  Changing this parameter will create a new resource.
+
+* `template_name` - (Required, String, ForceNew) Specifies the name of the add-on template.
+  Changing this parameter will create a new resource.
+
+* `version` - (Required, String, ForceNew) Specifies the version of the add-on.
+  Changing this parameter will create a new resource.
+
+* `values` - (Optional, List, ForceNew) Specifies the add-on template installation parameters.
+  These parameters vary depending on the add-on. Structure is documented below.
+  Changing this parameter will create a new resource.
+
+* The `values` block supports:
+
+* `basic_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
+  Changing this parameter will create a new resource.
+
+* `custom_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
+  Changing this parameter will create a new resource.
+
+* `flavor_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
+  Changing this parameter will create a new resource.
+
+* `basic` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+  Only supports non-nested structure and only supports string type elements.
+  This is an alternative to `basic_json`, but it is not recommended.
+  Changing this parameter will create a new resource.
+
+* `custom` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+  Only supports non-nested structure and only supports string type elements.
+  This is an alternative to `custom_json`, but it is not recommended.
+  Changing this parameter will create a new resource.
+
+* `flavor` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+  Only supports non-nested structure and only supports string type elements.
+  This is an alternative to `flavor_json`, but it is not recommended.
+  Changing this parameter will create a new resource.
+
+Arguments which can be passed to the `basic_json`, `custom_json` and `flavor_json` add-on parameters depends on
+the add-on type and version. For more detailed description of add-ons
+see [add-ons description](https://github.com/sbercloud-terraform/terraform-provider-sbercloud/blob/master/examples/cce/basic/cce-addon-templates.md)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the add-on instance.
+* `status` - Add-on status information.
+* `description` - Description of add-on instance.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 3 minute.
+
+## Import
+
+CCE add-on can be imported using the cluster ID and add-on ID separated by a slash, e.g.:
+
+```
+$ terraform import sbercloud_cce_addon.my_addon bb6923e4-b16e-11eb-b0cd-0255ac101da1/c7ecb230-b16f-11eb-b3b6-0255ac1015a3
+```

--- a/examples/cce/basic/cce-addon-templates.md
+++ b/examples/cce/basic/cce-addon-templates.md
@@ -1,0 +1,240 @@
+# CCE Addon Templates
+
+Addon support configuration input depending on addon type and version. This page contains description of addon
+arguments. You can get up to date reference of addon arguments for your cluster using data source
+[`sbercloud_cce_addon_template`](https://registry.terraform.io/providers/sbercloud-terraform/sbercloud/latest/docs/data-sources/cce_addon_template)
+.
+
+Following addon templates exist in the addon template list:
+
+- [`autoscaler`](#autoscaler)
+- [`coredns`](#coredns)
+- [`everest`](#everest)
+- [`metrics-server`](#metrics-server)
+- [`gpu-beta`](#gpu-beta)
+
+All addons accept `basic` and some can accept `custom`, `flavor` input values.
+It is recommended to use `basic_json`, `custom_json` and `flavor_json` for more flexible input.
+
+## Example Usage
+
+### Use basic_json, custom_json and flavor_json
+
+```hcl
+variable "cluster_id" {}
+variable "tenant_id" {}
+
+data "sbercloud_cce_addon_template" "autoscaler" {
+  cluster_id = var.cluster_id
+  name       = "autoscaler"
+  version    = "1.19.6"
+}
+
+resource "sbercloud_cce_addon" "autoscaler" {
+  cluster_id    = var.cluster_id
+  template_name = "autoscaler"
+  version       = "1.19.6"
+
+  values {
+    basic_json  = jsonencode(jsondecode(data.sbercloud_cce_addon_template.autoscaler.spec).basic)
+    custom_json = jsonencode(merge(
+      jsondecode(data.sbercloud_cce_addon_template.autoscaler.spec).parameters.custom,
+      {
+        cluster_id = var.cluster_id
+        tenant_id  = var.tenant_id
+      }
+    ))
+    flavor_json = jsonencode(jsondecode(data.sbercloud_cce_addon_template.autoscaler.spec).parameters.flavor2)
+  }
+}
+
+```
+
+### Use basic and custom
+
+```hcl
+variable "cluster_id" {}
+variable "tenant_id" {}
+
+data "sbercloud_cce_addon_template" "autoscaler" {
+  cluster_id = var.cluster_id
+  name       = "autoscaler"
+  version    = "1.19.6"
+}
+
+resource "sbercloud_cce_addon" "autoscaler" {
+  cluster_id    = var.cluster_id
+  template_name = "autoscaler"
+  version       = "1.19.6"
+
+  values {
+    basic  = jsondecode(data.sbercloud_cce_addon_template.autoscaler.spec).basic
+    custom = merge(
+      jsondecode(data.sbercloud_cce_addon_template.autoscaler.spec).parameters.custom,
+      {
+        cluster_id = var.cluster_id
+        tenant_id  = var.tenant_id
+      }
+    )
+  }
+}
+
+```
+
+## Addon Inputs
+
+### autoscaler
+
+A component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there
+are no unneeded nodes.
+`template_version`: `1.19.1`
+
+#### basic
+
+```json
+{
+  "cceEndpoint": "https://cce.ru-moscow-1.mysbercloud.com",
+  "ecsEndpoint": "https://ecs.ru-moscow-1.mysbercloud.com",
+  "image_version": "1.19.6",
+  "platform": "linux-amd64",
+  "region": "ru-moscow-1",
+  "swr_addr": "swr.ru-moscow-1.mysbercloud.com",
+  "swr_user": "hwofficial"
+}
+```
+
+#### custom
+
+```json
+{
+  "cluster_id": "",
+  "coresTotal": 32000,
+  "expander": "priority",
+  "logLevel": 4,
+  "maxEmptyBulkDeleteFlag": 10,
+  "maxNodeProvisionTime": 15,
+  "maxNodesTotal": 1000,
+  "memoryTotal": 128000,
+  "scaleDownDelayAfterAdd": 10,
+  "scaleDownDelayAfterDelete": 10,
+  "scaleDownDelayAfterFailure": 3,
+  "scaleDownEnabled": false,
+  "scaleDownUnneededTime": 10,
+  "scaleDownUtilizationThreshold": 0.5,
+  "scaleUpCpuUtilizationThreshold": 1,
+  "scaleUpMemUtilizationThreshold": 1,
+  "scaleUpUnscheduledPodEnabled": true,
+  "scaleUpUtilizationEnabled": true,
+  "tenant_id": "",
+  "unremovableNodeRecheckTimeout": 5
+}
+```
+
+### coredns
+
+CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services.
+`template_version`: `1.17.7`
+
+#### basic
+
+```json
+{
+  "cluster_ip": "10.247.3.10",
+  "image_version": "1.17.7",
+  "platform": "linux-amd64",
+  "swr_addr": "swr.ru-moscow-1.mysbercloud.com",
+  "swr_user": "hwofficial"
+}
+```
+
+#### custom
+
+```json
+{
+  "stub_domains": "",
+  "upstream_nameservers": ""
+}
+```
+
+### everest
+
+Everest is a cloud native container storage system based on CSI, used to support cloud storages services for Kubernetes.
+`template_version`: `1.2.9`
+
+#### basic
+
+```json
+{
+  "bms_url": "bms.ru-moscow-1.mysbercloud.com",
+  "controller_image_version": "1.2.9",
+  "driver_image_version": "1.2.9",
+  "ecsEndpoint": "https://ecs.ru-moscow-1.mysbercloud.com",
+  "evs_url": "evs.ru-moscow-1.mysbercloud.com",
+  "iam_url": "iam.ru-moscow-1.mysbercloud.com",
+  "ims_url": "ims.ru-moscow-1.mysbercloud.com",
+  "obs_url": "obs.ru-moscow-1.mysbercloud.com",
+  "platform": "linux-amd64",
+  "sfs_turbo_url": "sfs-turbo.ru-moscow-1.mysbercloud.com",
+  "sfs_url": "sfs.ru-moscow-1.mysbercloud.com",
+  "supportHcs": false,
+  "swr_addr": "swr.ru-moscow-1.mysbercloud.com",
+  "swr_user": "hwofficial"
+}
+```
+
+#### custom
+
+```json
+{
+  "cluster_id": "",
+  "default_vpc_id": "",
+  "disable_auto_mount_secret": false,
+  "project_id": ""
+}
+```
+
+### metrics-server
+
+Metrics Server is a cluster-level resource usage data aggregator.
+`template_version`: `1.1.2`
+
+#### basic
+
+```json
+{
+  "image_version": "v0.4.4",
+  "swr_addr": "swr.ru-moscow-1.mysbercloud.com",
+  "swr_user": "hwofficial"
+}
+```
+
+#### custom
+
+The custom block is *not supported*.
+
+### gpu-beta
+
+A device plugin for nvidia.com/gpu resource on nvidia driver.
+`template_version`: `1.2.2`
+
+#### basic
+
+```json
+{
+  "device_version": "1.2.2",
+  "driver_version": "1.2.2",
+  "obs_url": "obs.ru-moscow-1.mysbercloud.com",
+  "region": "ru-moscow-1",
+  "swr_addr": "swr.ru-moscow-1.mysbercloud.com",
+  "swr_user": "hwofficial"
+}
+```
+
+#### custom
+
+```json
+{
+  "is_driver_from_nvidia": true,
+  "nvidia_driver_download_url": ""
+}
+```

--- a/sbercloud/data_source_sbercloud_cce_addon_template_test.go
+++ b/sbercloud/data_source_sbercloud_cce_addon_template_test.go
@@ -1,0 +1,45 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.sbercloud_cce_addon_template.coredns_test", "spec"),
+					resource.TestCheckResourceAttrSet("data.sbercloud_cce_addon_template.metrics-server_test", "spec"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEAddonTemplateV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cce_addon_template" "coredns_test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = "coredns"
+  version    = "1.17.15"
+}
+
+data "sbercloud_cce_addon_template" "metrics-server_test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = "metrics-server"
+  version    = "1.1.10"
+}
+`, testAccCCEClusterV3_basic(rName))
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -140,6 +140,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sbercloud_availability_zones":     huaweicloud.DataSourceAvailabilityZones(),
 			"sbercloud_cbr_vaults":             cbr.DataSourceCbrVaultsV3(),
+			"sbercloud_cce_addon_template":     huaweicloud.DataSourceCCEAddonTemplateV3(),
 			"sbercloud_cce_cluster":            huaweicloud.DataSourceCCEClusterV3(),
 			"sbercloud_cce_node":               huaweicloud.DataSourceCCENodeV3(),
 			"sbercloud_cce_node_pool":          huaweicloud.DataSourceCCENodePoolV3(),
@@ -189,6 +190,7 @@ func Provider() *schema.Provider {
 			"sbercloud_cbr_policy":                      cbr.ResourceCBRPolicyV3(),
 			"sbercloud_cbr_vault":                       cbr.ResourceCBRVaultV3(),
 			"sbercloud_css_cluster":                     css.ResourceCssCluster(),
+			"sbercloud_cce_addon":                       huaweicloud.ResourceCCEAddonV3(),
 			"sbercloud_cce_cluster":                     huaweicloud.ResourceCCEClusterV3(),
 			"sbercloud_cce_node":                        huaweicloud.ResourceCCENodeV3(),
 			"sbercloud_cce_node_pool":                   huaweicloud.ResourceCCENodePool(),

--- a/sbercloud/resource_sbercloud_cce_addon_v3_test.go
+++ b/sbercloud/resource_sbercloud_cce_addon_v3_test.go
@@ -1,0 +1,247 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v3/addons"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCEAddonV3_basic(t *testing.T) {
+	var addon addons.Addon
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_addon.test"
+	clusterName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEAddonV3Exists(resourceName, clusterName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCEAddonImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func TestAccCCEAddonV3_values(t *testing.T) {
+	var addon addons.Addon
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_addon.test"
+	clusterName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonV3_values(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEAddonV3Exists(resourceName, clusterName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceAddonV3Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating SberCloud CCE Addon client: %s", err)
+	}
+
+	var clusterId string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "sbercloud_cce_cluster" {
+			clusterId = rs.Primary.ID
+		}
+
+		if rs.Type != "sbercloud_cce_addon" {
+			continue
+		}
+
+		if clusterId != "" {
+			_, err := addons.Get(cceClient, rs.Primary.ID, clusterId).Extract()
+			if err == nil {
+				return fmtp.Errorf("addon still exists")
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+		c, ok := s.RootModule().Resources[cluster]
+		if !ok {
+			return fmtp.Errorf("Cluster not found: %s", c)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+		if c.Primary.ID == "" {
+			return fmtp.Errorf("Cluster id is not set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceAddonV3Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating SberCloud CCE Addon client: %s", err)
+		}
+
+		found, err := addons.Get(cceClient, rs.Primary.ID, c.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmtp.Errorf("Addon not found")
+		}
+
+		*addon = *found
+
+		return nil
+	}
+}
+
+func testAccCCEAddonImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		var addonID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "sbercloud_cce_cluster" {
+				clusterID = rs.Primary.ID
+			} else if rs.Type == "sbercloud_cce_addon" {
+				addonID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || addonID == "" {
+			return "", fmtp.Errorf("resource not found: %s/%s", clusterID, addonID)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, addonID), nil
+	}
+}
+
+func testAccCCEAddonV3_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "c6.large.2"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+  os                = "CentOS 7.6"
+
+  root_volume {
+    size       = 50
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCEAddonV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_addon" "test" {
+  cluster_id    = sbercloud_cce_cluster.test.id
+  version       = "1.1.10"
+  template_name = "metrics-server"
+  depends_on    = [sbercloud_cce_node.test]
+}
+`, testAccCCEAddonV3_Base(rName))
+}
+
+func testAccCCEAddonV3_values(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node_pool" "test" {
+  cluster_id         = sbercloud_cce_cluster.test.id
+  name               = "%s"
+  os                 = "CentOS 7.6"
+  flavor_id          = "c6.large.2"
+  initial_node_count = 2
+  availability_zone  = data.sbercloud_availability_zones.test.names[0]
+  key_pair           = sbercloud_compute_keypair.test.name
+  scall_enable       = true
+  min_node_count     = 2
+  max_node_count     = 4
+  priority           = 1
+  type               = "vm"
+
+  root_volume {
+    size       = 50
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+data "sbercloud_cce_addon_template" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = "autoscaler"
+  version    = "1.19.9"
+}
+
+resource "sbercloud_cce_addon" "test" {
+  cluster_id    = sbercloud_cce_cluster.test.id
+  template_name = "autoscaler"
+  version       = "1.19.9"
+
+  values {
+    basic  = jsondecode(data.sbercloud_cce_addon_template.test.spec).basic
+    custom = merge(
+      jsondecode(data.sbercloud_cce_addon_template.test.spec).parameters.custom,
+      {
+        cluster_id = sbercloud_cce_cluster.test.id
+        tenant_id  = "%s"
+      }
+    )
+    flavor_json = jsonencode(jsondecode(data.sbercloud_cce_addon_template.test.spec).parameters.flavor2)
+  }
+
+  depends_on = [sbercloud_cce_node_pool.test]
+}
+`, testAccCCENodePool_Base(rName), rName, SBC_PROJECT_ID)
+}


### PR DESCRIPTION
This PR adds 2 objects:

**Data Sources**
sbercloud_cce_addon_template

**Resources**
sbercloud_cce_addon

This closes  #43 

All related CCE Addon acceptance tests are done:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccCCEAddon -timeout 360m -parallel=1
=== RUN   TestAccCCEAddonTemplateV3DataSource_basic
=== PAUSE TestAccCCEAddonTemplateV3DataSource_basic
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== RUN   TestAccCCEAddonV3_values
=== PAUSE TestAccCCEAddonV3_values
=== CONT  TestAccCCEAddonTemplateV3DataSource_basic
--- PASS: TestAccCCEAddonTemplateV3DataSource_basic (364.89s)
=== CONT  TestAccCCEAddonV3_values
--- PASS: TestAccCCEAddonV3_values (714.48s)
=== CONT  TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (728.34s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud   1808.084s
```