### PR TITLE
feat(ECS): add new datasources

### DIFF
--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# sbercloud_compute_instance
+
+Use this data source to get the details of a specified compute instance.
+
+## Example Usage
+
+```hcl
+variable "ecs_name" {}
+
+data "sbercloud_compute_instance" "demo" {
+  name = var.ecs_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the instance. If omitted, the provider-level region will
+  be used.
+
+* `name` - (Optional, String) Specifies the ECS name, which can be queried with a regular expression.
+
+* `fixed_ip_v4` - (Optional, String)  Specifies the IPv4 addresses of the ECS.
+
+* `flavor_id` - (Optional, String) Specifies the flavor ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The instance ID in UUID format.
+* `availability_zone` - The availability zone where the instance is located.
+* `image_id` - The image ID of the instance.
+* `image_name` - The image name of the instance.
+* `flavor_name` - The flavor name of the instance.
+* `key_pair` - The key pair that is used to authenticate the instance.
+* `public_ip` - The EIP address that is associted to the instance.
+* `system_disk_id` - The system disk voume ID.
+* `user_data` - The user data (information after encoding) configured during instance creation.
+* `security_group_ids` - An array of one or more security group IDs to associate with the instance.
+* `network` - An array of one or more networks to attach to the instance. The network object structure is documented
+  below.
+* `volume_attached` - An array of one or more disks to attach to the instance. The volume_attached object structure is
+  documented below.
+* `scheduler_hints` - The scheduler with hints on how the instance should be launched. The available hints are described
+  below.
+* `tags` - The key/value pairs to associate with the instance.
+* `status` - The status of the instance.
+
+The `network` block supports:
+
+* `uuid` - The network UUID to attach to the server.
+* `port` - The port ID corresponding to the IP address on that network.
+* `mac` - The MAC address of the NIC on that network.
+* `fixed_ip_v4` - The fixed IPv4 address of the instance on this network.
+* `fixed_ip_v6` - The Fixed IPv6 address of the instance on that network.
+
+The `volume_attached` block supports:
+
+* `volume_id` - The volume id on that attachment.
+* `boot_index` - The volume boot index on that attachment.
+* `size` - The volume size on that attachment.
+* `type` - The volume type on that attachment.
+* `pci_address` - The volume pci address on that attachment.
+
+The `scheduler_hints` block supports:
+
+* `group` - The UUID of a Server Group where the instance will be placed into.

--- a/docs/data-sources/compute_instances.md
+++ b/docs/data-sources/compute_instances.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# sbercloud_compute_instances
+
+Use this data source to get the list of the compute instances.
+
+## Example Usage
+
+```hcl
+variable "name_regex" {}
+
+data "sbercloud_compute_instances" "test" {
+  name = var.name_regex
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the instances.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the instance name, which can be queried with a regular expression.
+  The instance name supports fuzzy matching query too.
+
+* `flavor_name` - (Optional, String) Specifies the flavor name of the instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+* `status` - (Optional, String) Specifies the status of the instance. The valid values are as follows:
+  + **ACTIVE**: The instance is running properly.
+  + **SHUTOFF**: The instance has been properly stopped.
+  + **ERROR**: An error has occurred on the instance.
+
+* `image_id` - (Optional, String) Specifies the image ID of the instance.
+
+* `flavor_id` - (Optional, String) Specifies the flavor ID.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone where the instance is located.
+  Please following [reference](https://support.hc.sbercloud.ru/endpoint/index.html) for this argument.
+
+* `key_pair` - (Optional, String) Specifies the key pair that is used to authenticate the instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `instances` - List of ECS instance details. The object structure of each ECS instance is documented below.
+
+The `instances` block supports:
+
+* `id` - The instance ID in UUID format.
+
+* `name` - The instance name.
+
+* `image_id` - The image ID of the instance.
+
+* `flavor_id` - The flavor ID.
+
+* `flavor_name` - The flavor name of the instance.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `status` - The instance status.
+
+* `availability_zone` - The availability zone where the instance is located.
+
+* `key_pair` - The key pair that is used to authenticate the instance.
+
+* `security_group_ids` - An array of one or more security group IDs to associate with the instance.
+
+* `user_data` - The user data (information after encoding) configured during instance creation.
+
+* `volume_attached` - An array of one or more disks to attach to the instance. The object structure is documented below.
+
+* `scheduler_hints` - The scheduler with hints on how the instance should be launched.
+  The object structure is documented below.
+
+* `tags` - The key/value pairs to associate with the instance.
+
+The `volume_attached` block supports:
+
+* `volume_id` - The volume id on that attachment.
+
+* `is_sys_volume` - Whether the volume is the system disk.
+
+The `scheduler_hints` block supports:
+
+* `group` - The UUID of a server group where the instance will be placed into.

--- a/sbercloud/data_source_sbercloud_compute_instance_test.go
+++ b/sbercloud/data_source_sbercloud_compute_instance_test.go
@@ -1,0 +1,137 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccComputeInstanceDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("ecs-data-test-%s", acctest.RandString(5))
+	resourceName := "data.sbercloud_compute_instance.this"
+	var instance cloudservers.CloudServer
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists("sbercloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstanceDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Can't find compute instance data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("Compute instance data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeInstanceDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_compute_instance" "test" {
+  name               = "%s"
+  image_id           = data.sbercloud_images_image.test.id
+  flavor_id          = data.sbercloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.sbercloud_networking_secgroup.test.id]
+  availability_zone  = data.sbercloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.sbercloud_vpc_subnet.test.id
+  }
+}
+
+data "sbercloud_compute_instance" "this" {
+  name = sbercloud_compute_instance.test.name
+
+  depends_on = [
+    sbercloud_compute_instance.test
+  ]
+}
+`, testAccCompute_data, rName)
+}
+
+func testAccCheckComputeInstanceExists(n string, instance *cloudservers.CloudServer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		computeClient, err := config.ComputeV1Client(SBC_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating SberCloud compute client: %s", err)
+		}
+
+		found, err := cloudservers.Get(computeClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmtp.Errorf("Instance not found")
+		}
+
+		*instance = *found
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	computeClient, err := config.ComputeV1Client(SBC_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating SberCloud compute client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sbercloud_compute_instance" {
+			continue
+		}
+
+		server, err := cloudservers.Get(computeClient, rs.Primary.ID).Extract()
+		if err == nil {
+			if server.Status != "DELETED" {
+				return fmtp.Errorf("Instance still exists")
+			}
+		}
+	}
+
+	return nil
+}

--- a/sbercloud/data_source_sbercloud_compute_instances_test.go
+++ b/sbercloud/data_source_sbercloud_compute_instances_test.go
@@ -1,0 +1,90 @@
+package sbercloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccComputeInstancesDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.sbercloud_compute_instances.test"
+	var instance cloudservers.CloudServer
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstancesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists("sbercloud_compute_instance.test", &instance),
+					testAccCheckComputeInstancesDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.image_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.flavor_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.availability_zone"),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.security_group_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstancesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Can't find compute instances data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("Data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeInstancesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_compute_instance" "test" {
+  name               = "%s"
+  image_id           = data.sbercloud_images_image.test.id
+  flavor_id          = data.sbercloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.sbercloud_networking_secgroup.test.id]
+  availability_zone  = data.sbercloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.sbercloud_vpc_subnet.test.id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+data "sbercloud_compute_instances" "test" {
+  name = sbercloud_compute_instance.test.name
+
+  depends_on = [
+    sbercloud_compute_instance.test
+  ]
+}
+`, testAccCompute_data, rName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -147,6 +147,8 @@ func Provider() *schema.Provider {
 			"sbercloud_cce_node_pool":          huaweicloud.DataSourceCCENodePoolV3(),
 			"sbercloud_cdm_flavors":            huaweicloud.DataSourceCdmFlavorV1(),
 			"sbercloud_compute_flavors":        huaweicloud.DataSourceEcsFlavors(),
+			"sbercloud_compute_instance":       huaweicloud.DataSourceComputeInstance(),
+			"sbercloud_compute_instances":      huaweicloud.DataSourceComputeInstances(),
 			"sbercloud_dcs_az":                 deprecated.DataSourceDcsAZV1(),
 			"sbercloud_dcs_maintainwindow":     dcs.DataSourceDcsMaintainWindow(),
 			"sbercloud_dcs_product":            deprecated.DataSourceDcsProductV1(),

--- a/sbercloud/resource_sbercloud_compute_instance_test.go
+++ b/sbercloud/resource_sbercloud_compute_instance_test.go
@@ -233,6 +233,10 @@ data "sbercloud_images_image" "test" {
   name        = "Ubuntu 18.04 server 64bit"
   most_recent = true
 }
+
+data "sbercloud_networking_secgroup" "test" {
+  name = "default"
+}
 `
 
 func testAccComputeV2Instance_basic(rName string) string {


### PR DESCRIPTION
This PR adds 2 datasources:

sbercloud_compute_instance
sbercloud_compute_instances

This closes #148 

All acceptance tests are done:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccComputeInstanceDataSource -timeout 360m -parallel=1
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (131.49s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud
```
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud -v -run TestAccComputeInstancesDataSource -timeout 360m -parallel=1
=== RUN   TestAccComputeInstancesDataSource_basic
=== PAUSE TestAccComputeInstancesDataSource_basic
=== CONT  TestAccComputeInstancesDataSource_basic
--- PASS: TestAccComputeInstancesDataSource_basic (130.01s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud
```

