### PR TITLE
docs(network-acl): update the documentation

### DIFF
--- a/docs/resources/network_acl.md
+++ b/docs/resources/network_acl.md
@@ -34,7 +34,8 @@ resource "sbercloud_network_acl_rule" "rule_2" {
 resource "sbercloud_network_acl" "fw_acl" {
   name          = "my-fw-acl"
   subnets       = [data.sbercloud_vpc_subnet.subnet.id]
-  inbound_rules = [sbercloud_network_acl_rule.rule_1.id,
+  inbound_rules = [
+    sbercloud_network_acl_rule.rule_1.id,
     sbercloud_network_acl_rule.rule_2.id]
 }
 ```
@@ -43,13 +44,14 @@ resource "sbercloud_network_acl" "fw_acl" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the network acl resource. If omitted, the provider-level region will be used. Changing this creates a new network acl resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the network acl resource. If omitted, the
+  provider-level region will be used. Changing this creates a new network acl resource.
 
 * `name` - (Required, String) Specifies the network ACL name. This parameter can contain a maximum of 64 characters,
-    which may consist of letters, digits, underscores (_), and hyphens (-).
+  which may consist of letters, digits, underscores (_), and hyphens (-).
 
-* `description` - (Optional, String) Specifies the supplementary information about the network ACL.
-    This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
+* `description` - (Optional, String) Specifies the supplementary information about the network ACL. This parameter can
+  contain a maximum of 255 characters and cannot contain angle brackets (< or >).
 
 * `inbound_rules` - (Optional, List)  A list of the IDs of ingress rules associated with the network ACL.
 
@@ -68,8 +70,9 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The status of the network ACL.
 
 ## Timeouts
-This resource provides the following timeouts configuration options:
-- `create` - Default is 10 minute.
-- `update` - Default is 10 minute.
-- `delete` - Default is 10 minute.
 
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -6,7 +6,7 @@ subcategory: "Network ACL"
 
 Manages a network ACL rule resource within SberCloud.
 
-## Example Usage
+## Basic Usage
 
 ```hcl
 resource "sbercloud_network_acl_rule" "rule_1" {
@@ -20,38 +20,50 @@ resource "sbercloud_network_acl_rule" "rule_1" {
 }
 ```
 
+## Create a network acl rule with range port
+
+```hcl
+resource "sbercloud_network_acl_rule" "rule_2" {
+  protocol               = "tcp"
+  ip_version             = 4
+  action                 = "allow"
+  destination_port       = "1:100"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the network ACL rule resource. If omitted, the provider-level region will be used. Changing this creates a new network ACL rule resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the network ACL rule resource. If omitted, the
+  provider-level region will be used. Changing this creates a new network ACL rule resource.
 
 * `name` - (Optional, String) Specifies a unique name for the network ACL rule.
 
 * `description` - (Optional, String) Specifies the description for the network ACL rule.
 
-* `protocol` - (Required, String) Specifies the protocol supported by the network ACL rule.
-     Valid values are: *tcp*, *udp*, *icmp* and *any*.
+* `protocol` - (Required, String) Specifies the protocol supported by the network ACL rule. Valid values are: *tcp*,
+  *udp*, *icmp* and *any*.
 
-* `action` - (Required, String) Specifies the action in the network ACL rule. Currently, the value can be *allow* or *deny*.
+* `action` - (Required, String) Specifies the action in the network ACL rule. Currently, the value can be *allow* or
+  *deny*.
 
-* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6. This parameter is
-    available after the IPv6 function is enabled.
+* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6. This parameter is available after
+  the IPv6 function is enabled.
 
-* `source_ip_address` - (Optional, String) Specifies the source IP address that the traffic is allowed from.
-    The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+* `source_ip_address` - (Optional, String) Specifies the source IP address that the traffic is allowed from. The default
+  value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
 * `destination_ip_address` - (Optional, String) Specifies the destination IP address to which the traffic is allowed.
-    The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+  The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
-* `source_port` - (Optional, String) Specifies the source port number or port number range. The value ranges from 1 to 65535.
-    For a port number range, enter two port numbers connected by a hyphen (-). For example, 1-100.
+* `source_port` - (Optional, String) Specifies the source port number or port number range. The value ranges from 1 to
+  65535. For a port number range, enter two port numbers connected by a colon(:). For example, 1:100.
 
-* `destination_port` - (Optional, String) Specifies the destination port number or port number range. The value ranges from 1 to 65535.
-    For a port number range, enter two port numbers connected by a hyphen (-). For example, 1-100.
+* `destination_port` - (Optional, String) Specifies the destination port number or port number range. The value ranges
+  from 1 to 65535. For a port number range, enter two port numbers connected by a colon(:). For example, 1:100.
 
 * `enabled` - (Optional, Bool) Enabled status for the network ACL rule. Defaults to true.
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR updates the documentation for the following resources:

sbercloud_network_acl
sbercloud_network_acl_rule

This closes #141 