### PR TITLE
Add new CCE objects

### DIFF
--- a/docs/data-sources/cce_clusters.md
+++ b/docs/data-sources/cce_clusters.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_clusters
+
+Use this data source to get a list of CCE clusters.
+
+## Example Usage
+
+```hcl
+variable "cluster_name" {}
+
+data "sbercloud_cce_clusters" "clusters" {
+  name   = var.cluster_name
+  status = "Available"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CCE clusters. If omitted, the
+  provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the cluster.
+
+* `cluster_id` - (Optional, String) Specifies the ID of the cluster.
+
+* `cluster_type` - (Optional, String) Specifies the type of the cluster. Possible values: **VirtualMachine**, **BareMetal**.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID to which the cluster belongs.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the cluster.
+
+* `status` - (Optional, String) Specifies the status of the cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `ids` - Indicates a list of IDs of all CCE clusters found.
+
+* `clusters` - Indicates a list of CCE clusters found. Structure is documented below.
+
+The `clusters` block supports:
+
+* `name` - The name of the cluster.
+
+* `id` - The ID of the cluster.
+
+* `cluster_type` - The type of the cluster. Possible values: **VirtualMachine**, **ARM64**.
+
+* `status` - The status of the cluster.
+
+* `flavor_id` - The specification of the cluster.
+
+* `cluster_version` - The version of the cluster.
+
+* `description` - The description of the cluster.
+
+* `billing_mode` - The charging mode of the cluster.
+
+* `container_network_cidr` - The container network segment.
+
+* `container_network_type` - The container network type: **overlay_l2** , **underlay_ipvlan**, **vpc-router** or **eni**.
+
+* `eni_subnet_id` - The ENI subnet ID.
+
+* `eni_subnet_cidr` - The ENI network segment.
+
+* `service_network_cidr` - The service network segment.
+
+* `authentication_mode` - The authentication mode of the cluster, possible values are x509 and rbac. Defaults to **rbac**.
+
+* `masters` - The advanced configuration of master nodes.
+
+* `security_group_id` - The security group ID of the cluster.
+
+* `vpc_id` - The vpc ID of the cluster.
+
+* `subnet_id` - The ID of the subnet used to create the node.
+
+* `highway_subnet_id` - The ID of the high speed network used to create bare metal nodes.
+
+* `enterprise_project_id` - The enterprise project ID of the CCE cluster.
+
+* `endpoints` - The access addresses of kube-apiserver in the cluster. Structure is documented below.
+
+* `certificate_clusters` - The certificate clusters. Structure is documented below.
+
+* `certificate_users` - The certificate users. Structure is documented below.
+
+* `kube_config_raw` - The raw Kubernetes config to be used by kubectl and other compatible tools.
+
+The `endpoints` block supports:
+
+* `url` - The URL of the cluster access address.
+
+* `type` - The type of the cluster access address.
+  + **Internal**: The user's subnet access address.
+  + **External**: The public network access address.
+
+The `certificate_clusters` block supports:
+
+* `name` - The cluster name.
+
+* `server` - The server IP address.
+
+* `certificate_authority_data` - The certificate data.
+
+The `certificate_users` block supports:
+
+* `name` - The user name.
+
+* `client_certificate_data` - The client certificate data.
+
+* `client_key_data` - The client key data.

--- a/docs/data-sources/cce_nodes.md
+++ b/docs/data-sources/cce_nodes.md
@@ -1,0 +1,86 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_nodes
+
+Use this data source to get a list of CCE nodes.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "node_name" {}
+
+data "sbercloud_cce_nodes" "node" {
+  cluster_id = var.cluster_id
+  name       = var.node_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CCE nodes. If omitted, the provider-level
+  region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of CCE cluster.
+
+* `name` - (Optional, String) Specifies the of the node.
+
+* `node_id` - (Optional, String) Specifies the ID of the node.
+
+* `status` - (Optional, String) Specifies the status of the node.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `ids` - Indicates a list of IDs of all CCE nodes found.
+
+* `nodes` - Indicates a list of CCE nodes found. Structure is documented below.
+
+The `nodes` block supports:
+
+* `name` - The name of the node.
+
+* `id` - The ID of the node.
+
+* `status` - The state of the node.
+
+* `flavor_id` - The flavor ID to be used.
+
+* `availability_zone` - The available partitions where the node is located.
+
+* `os` - The operating System of the node.
+
+* `subnet_id` - The ID of the subnet to which the NIC belongs.
+
+* `ecs_group_id` - The ID of ECS group to which the node belongs.
+
+* `tags` - The tags of a VM node, key/value pair format.
+
+* `key_pair` - The key pair name when logging in to select the key pair mode.
+
+* `billing_mode` - The node's billing mode: The value is 0 (on demand).
+
+* `server_id` - The node's virtual machine ID in ECS.
+
+* `public_ip` - The elastic IP parameters of the node.
+
+* `private_ip` - The private IP of the node.
+
+* `root_volume` - The system disk related configuration. Structure is documented below.
+
+* `data_volumes` - The data related configuration. Structure is documented below.
+
+The `root_volume` and `data_volumes` blocks support:
+
+* `size` - Disk size in GB.
+
+* `volumetype` - Disk type.
+
+* `extend_params` - Disk expansion parameters.

--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -2,7 +2,7 @@
 subcategory: "Cloud Container Engine (CCE)"
 ---
 
-# sbercloud\_cce\_cluster
+# sbercloud_cce_cluster
 
 Provides a CCE cluster resource.
 

--- a/docs/resources/cce_namespace.md
+++ b/docs/resources/cce_namespace.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_namespace
+
+Manages a CCE namespace resource within SberCloud.
+
+## Example Usage
+
+### Basic
+
+```hcl
+variable "cluster_id" {}
+
+resource "sbercloud_cce_namespace" "test" {
+  cluster_id = var.cluster_id
+  name       = "test-namespace"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the namespace resource.
+  If omitted, the provider-level region will be used. Changing this will create a new namespace resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID to which the CCE namespace belongs.
+  Changing this will create a new namespace resource.
+
+* `name` - (Optional, String, ForceNew) Specifies the unique name of the namespace.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens (-),
+  and must start and end with lowercase letters and digits. Changing this will create a new namespace resource.
+  Exactly one of `name` or `prefix` must be provided.
+
+* `prefix` - (Optional, String, ForceNew) Specifies a prefix used by the server to generate a unique name.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and
+  hyphens (-), and must start and end with lowercase letters and digits.
+  Changing this will create a new namespace resource. Exactly one of `name` or `prefix` must be provided.
+
+* `annotations` - (Optional, Map, ForceNew) Specifies an unstructured key value map for external parameters.
+  Changing this will create a new namespace resource.
+
+* `labels` - (Optional, Map, ForceNew) Specifies the map of string keys and values for labels.
+  Changing this will create a new namespace resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The namespace ID in UUID format.
+
+* `creation_timestamp` - The server time when namespace was created.
+
+* `status` - The current phase of the namespace.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 5 minute.
+
+## Import
+
+CCE namespace can be imported using the cluster ID and namespace name separated by a slash, e.g.:
+
+```
+$ terraform import sbercloud_cce_namespace.test bb6923e4-b16e-11eb-b0cd-0255ac101da1/test-namespace
+```

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -31,14 +31,15 @@ resource "sbercloud_cce_node" "node" {
   flavor_id         = "s3.large.2"
   availability_zone = data.sbercloud_availability_zones.myaz.names[0]
   key_pair          = sbercloud_compute_keypair.mykp.name
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
 }
 ```
@@ -52,14 +53,15 @@ resource "sbercloud_cce_node" "mynode" {
   flavor_id         = "s3.large.2"
   availability_zone = data.sbercloud_availability_zones.myaz.names[0]
   key_pair          = sbercloud_compute_keypair.mykp.name
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
 
   // Assign EIP
@@ -91,14 +93,15 @@ resource "sbercloud_cce_node" "mynode" {
   flavor_id         = "s3.large.2"
   availability_zone = data.sbercloud_availability_zones.myaz.names[0]
   key_pair          = sbercloud_compute_keypair.mykp.name
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
 
   // Assign existing EIP
@@ -115,9 +118,10 @@ resource "sbercloud_cce_node" "mynode" {
   flavor_id         = "s3.large.2"
   availability_zone = data.sbercloud_availability_zones.myaz.names[0]
   key_pair          = sbercloud_compute_keypair.mykp.name
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
+    size       = 50
     volumetype = "SSD"
   }
   data_volumes {
@@ -398,7 +402,7 @@ CCE node can be imported using the cluster ID and node ID separated by a slash, 
 $ terraform import sbercloud_cce_node.my_node 5c20fdad-7288-11eb-b817-0255ac10158b/e9287dff-7288-11eb-b817-0255ac10158b
 ```
 
-Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
 `password`, `fixed_ip`, `eip_id`, `preinstall`, `postinstall`, `iptype`, `bandwidth_charge_mode`, `bandwidth_size`,
 `share_type`, `max_pods`, `extend_param`, `labels`, `taints` and arguments for pre-paid. It is generally recommended

--- a/docs/resources/cce_node_attach.md
+++ b/docs/resources/cce_node_attach.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_node_attach
+
+Add a node from an existing ecs server to a CCE cluster.
+
+## Basic Usage
+
+```hcl
+resource "sbercloud_cce_node_attach" "test" {
+  cluster_id = var.cluster_id
+  server_id  = var.server_id
+  key_pair   = var.keypair_name
+  os         = "CentOS 7.6"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the CCE node attach resource. If omitted, the
+  provider-level region will be used. Changing this creates a new CCE node attach resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the cluster. Changing this parameter will create a new
+  resource.
+
+* `name` - (Optional, String) Specifies the Node Name.
+
+* `server_id` - (Required, String, ForceNew) Specifies the ecs server ID. Changing this parameter will create a new
+  resource.
+
+* `os` - (Required, String) Specifies the operating System of the node. Changing this parameter will reset the node.
+  + For VM nodes, clusters of v1.13 and later support *CentOS 7.6* and *Ubuntu 18.04*.
+
+* `key_pair` - (Optional, String) Specifies the key pair name when logging in to select the key pair mode.
+  This parameter and `password` are alternative. Changing this parameter will reset the node.
+
+* `password` - (Optional, String) Specifies the root password when logging in to select the password mode.
+  This parameter can be plain or salted and is alternative to `key_pair`.
+  Changing this parameter will reset the node.
+
+* `max_pods` - (Optional, Int, ForceNew) Specifies the the maximum number of instances a node is allowed to create.
+  Changing this parameter will create a new resource.
+
+* `docker_base_size` - (Optional, Int, ForceNew) Specifies the available disk space of a single docker container on the
+  node in device mapper mode. Changing this parameter will create a new resource.
+
+* `lvm_config` - (Optional, String, ForceNew) Specifies the docker data disk configurations. The following is an
+  example:
+
+```hcl
+  lvm_config = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG"
+```
+
+Changing this parameter will create a new resource.
+
+* `preinstall` - (Optional, String, ForceNew) Specifies the script required before installation. The input value can be
+  a Base64 encoded string or not. Changing this parameter will create a new resource.
+
+* `postinstall` - (Optional, String, ForceNew) Specifies the script required after installation. The input value can be
+  a Base64 encoded string or not. Changing this parameter will create a new resource.
+
+* `labels` - (Optional, Map, ForceNew) Specifies the tags of a Kubernetes node, key/value pair format.
+  Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
+
+* `taints` - (Optional, List, ForceNew) Specifies the taints configuration of the nodes to set anti-affinity.
+  Changing this parameter will create a new resource. Each taint contains the following parameters:
+
+  + `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit.
+    Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used
+    as the prefix of a key. Changing this parameter will create a new resource.
+  + `value` - (Required, String, ForceNew) A value must start with a letter or digit and can contain a maximum of 63
+    characters, including letters, digits, hyphens (-), underscores (_), and periods (.). Changing this parameter will
+    create a new resource.
+  + `effect` - (Required, String, ForceNew) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
+    Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+* `status` - Node status information.
+* `private_ip` - Private IP of the CCE node.
+* `public_ip` - Public IP of the CCE node.
+* `flavor_id` - The flavor ID of the CCE node.
+* `availability_zone` - The name of the available partition (AZ).
+* `root_volume` - The system disk related configuration.
+* `data_volumes` - The data disks related configuration.
+* `runtime` - The runtime of the CCE node.
+* `ecs_group_id` - The Ecs group ID.
+* `subnet_id` - The ID of the subnet to which the NIC belongs.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minute.
+* `update` - Default is 20 minute.
+* `delete` - Default is 20 minute.

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -16,7 +16,7 @@ variable "availability_zone" {}
 resource "sbercloud_cce_node_pool" "node_pool" {
   cluster_id               = var.cluster_id
   name                     = "testpool"
-  os                       = "EulerOS 2.5"
+  os                       = "CentOS 7.6"
   initial_node_count       = 2
   flavor_id                = "s3.large.4"
   availability_zone        = var.availability_zone
@@ -29,7 +29,7 @@ resource "sbercloud_cce_node_pool" "node_pool" {
   type                     = "vm"
 
   root_volume {
-    size       = 40
+    size       = 50
     volumetype = "SAS"
   }
   data_volumes {

--- a/docs/resources/cce_pvc.md
+++ b/docs/resources/cce_pvc.md
@@ -1,0 +1,150 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# sbercloud_cce_pvc
+
+Manages a CCE Persistent Volume Claim resource within SberCloud.
+
+## Example Usage
+
+### Create PVC with EVS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = var.cluster_id
+  namespace   = var.namespace
+  name        = var.pvc_name
+  annotations = {
+    "everest.io/disk-volume-type" = "SSD"
+  }
+  storage_class_name = "csi-disk"
+  access_modes = ["ReadWriteOnce"]
+  storage = "10Gi"
+}
+```
+
+### Create PVC with OBS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = var.cluster_id
+  namespace   = var.namespace
+  name        = var.pvc_name
+  annotations = {
+    "everest.io/obs-volume-type" = "STANDARD"
+    "csi.storage.k8s.io/fstype" =  "obsfs"
+  }
+  storage_class_name = "csi-obs"
+  access_modes = ["ReadWriteMany"]
+  storage = "1Gi"
+}
+```
+
+### Create PVC with SFS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = var.cluster_id
+  namespace   = var.namespace
+  name        = var.pvc_name
+  storage_class_name = "csi-nas"
+  access_modes = ["ReadWriteMany"]
+  storage = "10Gi"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the PVC resource.
+  If omitted, the provider-level region will be used. Changing this will create a new PVC resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID to which the CCE PVC belongs.
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace to logically divide your containers into different
+  group. Changing this will create a new PVC resource.
+
+* `name` - (Required, String, ForceNew) Specifies the unique name of the PVC resource. This parameter can contain a
+  maximum of 63 characters, which may consist of lowercase letters, digits and hyphens (-), and must start and end with
+  lowercase letters and digits. Changing this will create a new PVC resource.
+
+* `annotations` - (Optional, Map, ForceNew) Specifies the unstructured key value map for external parameters.
+  Changing this will create a new PVC resource.
+
+* `labels` - (Optional, Map, ForceNew) Specifies the map of string keys and values for labels.
+  Changing this will create a new PVC resource.
+
+* `storage_class_name` - (Required, String, ForceNew) Specifies the type of the storage bound to the CCE PVC.
+  The valid values are as follows:
+  + **csi-disk**: EVS.
+  + **csi-obs**: OBS.
+  + **csi-nas**: SFS.
+  + **csi-sfsturbo**: SFS-Turbo.
+
+* `access_modes` - (Required, List, ForceNew) Specifies the desired access modes the volume should have.
+  The valid values are as follows:
+  + **ReadWriteOnce**: The volume can be mounted as read-write by a single node.
+  + **ReadOnlyMany**: The volume can be mounted as read-only by many nodes.
+  + **ReadWriteMany**: The volume can be mounted as read-write by many nodes.
+
+* `storage` - (Required, String, ForceNew) Specifies the minimum amount of storage resources required.
+  Changing this creates a new PVC resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The PVC ID in UUID format.
+
+* `creation_timestamp` - The server time when PVC was created.
+
+* `status` - The current phase of the PVC.
+  + **Pending**: Not yet bound.
+  + **Bound**: Already bound.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 3 minute.
+
+## Import
+
+CCE PVC can be imported using the cluster ID, namespace and name separated by a slash, e.g.
+
+```
+$ terraform import sbercloud_cce_pvc.test 5c20fdad-7288-11eb-b817-0255ac10158b/default/pvc_name
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `annotations`.
+It is generally recommended running `terraform plan` after importing a PVC.
+You can then decide if changes should be applied to the PVC, or the resource
+definition should be updated to align with the PVC. Also you can ignore changes as below.
+
+```
+resource "sbercloud_cce_pvc" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      annotations,
+    ]
+  }
+}
+```

--- a/sbercloud/cce/data_source_sbercloud_cce_addon_template_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_addon_template_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -6,14 +6,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 )
 
 func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),

--- a/sbercloud/cce/data_source_sbercloud_cce_cluster_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_cluster_test.go
@@ -52,6 +52,8 @@ func testAccCCEClusterV3DataSource_basic(rName string) string {
 
 data "sbercloud_cce_cluster" "test" {
   name = sbercloud_cce_cluster.test.name
+
+  depends_on = [sbercloud_cce_cluster.test]
 }
 `, testAccCCEClusterV3_basic(rName))
 }

--- a/sbercloud/cce/data_source_sbercloud_cce_cluster_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_cluster_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 )
 
 func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
@@ -14,8 +15,8 @@ func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
 	resourceName := "data.sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3DataSource_basic(rName),

--- a/sbercloud/cce/data_source_sbercloud_cce_clusters_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_clusters_test.go
@@ -1,0 +1,43 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func TestAccCCEClustersDataSource_basic(t *testing.T) {
+	dataSourceName := "data.sbercloud_cce_clusters.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClustersV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.status", "Available"),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.cluster_type", "VirtualMachine"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEClustersV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cce_clusters" "test" {
+  name = sbercloud_cce_cluster.test.name
+
+  depends_on = [sbercloud_cce_cluster.test]
+}
+`, testAccCceCluster_config(rName))
+}

--- a/sbercloud/cce/data_source_sbercloud_cce_node_pool_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_node_pool_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 )
 
 func TestAccCCENodePoolV3DataSource_basic(t *testing.T) {
@@ -14,8 +15,8 @@ func TestAccCCENodePoolV3DataSource_basic(t *testing.T) {
 	resourceName := "data.sbercloud_cce_node_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePoolV3DataSource_basic(rName),

--- a/sbercloud/cce/data_source_sbercloud_cce_node_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_node_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 )
 
 func TestAccCCENodeV3DataSource_basic(t *testing.T) {
@@ -14,8 +15,8 @@ func TestAccCCENodeV3DataSource_basic(t *testing.T) {
 	resourceName := "data.sbercloud_cce_node.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3DataSource_basic(rName),

--- a/sbercloud/cce/data_source_sbercloud_cce_nodes_test.go
+++ b/sbercloud/cce/data_source_sbercloud_cce_nodes_test.go
@@ -1,0 +1,43 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCCENodesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.sbercloud_cce_nodes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "nodes.0.name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCENodesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_cce_nodes" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = sbercloud_cce_node.test.name
+
+  depends_on = [sbercloud_cce_node.test]
+}
+`, testAccCceCluster_config(rName))
+}

--- a/sbercloud/cce/resource_sbercloud_cce_addon_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_addon_test.go
@@ -161,7 +161,7 @@ func testAccCCEAddonV3_Base(rName string) string {
 resource "sbercloud_cce_node" "test" {
   cluster_id        = sbercloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "c6.large.2"
+  flavor_id         = "c6nl.large.2"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
   os                = "CentOS 7.6"
@@ -199,7 +199,7 @@ resource "sbercloud_cce_node_pool" "test" {
   cluster_id         = sbercloud_cce_cluster.test.id
   name               = "%s"
   os                 = "CentOS 7.6"
-  flavor_id          = "c6.large.2"
+  flavor_id          = "c6nl.large.2"
   initial_node_count = 2
   availability_zone  = data.sbercloud_availability_zones.test.names[0]
   key_pair           = sbercloud_compute_keypair.test.name

--- a/sbercloud/cce/resource_sbercloud_cce_addon_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_addon_test.go
@@ -1,10 +1,11 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -22,9 +23,9 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 	clusterName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonV3_basic(rName),
@@ -52,10 +53,10 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			acceptance.TestAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonV3_values(rName),
@@ -69,8 +70,8 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 }
 
 func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceAddonV3Client(SBC_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceAddonV3Client(acceptance.SBC_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating SberCloud CCE Addon client: %s", err)
 	}
@@ -114,8 +115,8 @@ func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon)
 			return fmtp.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceAddonV3Client(SBC_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceAddonV3Client(acceptance.SBC_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating SberCloud CCE Addon client: %s", err)
 		}
@@ -243,5 +244,5 @@ resource "sbercloud_cce_addon" "test" {
 
   depends_on = [sbercloud_cce_node_pool.test]
 }
-`, testAccCCENodePool_Base(rName), rName, SBC_PROJECT_ID)
+`, testAccCCENodePool_Base(rName), rName, acceptance.SBC_PROJECT_ID)
 }

--- a/sbercloud/cce/resource_sbercloud_cce_cluster_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_cluster_test.go
@@ -96,7 +96,7 @@ func TestAccCCEClusterV3_withEpsId(t *testing.T) {
 				Config: testAccCCEClusterV3_withEpsId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID),
 				),
 			},
 		},
@@ -247,5 +247,5 @@ resource "sbercloud_cce_cluster" "test" {
   enterprise_project_id  = "%s"
 }
 
-`, testAccCCEClusterV3_Base(rName), rName, acceptance.SBC_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccCCEClusterV3_Base(rName), rName, acceptance.SBC_ENTERPRISE_PROJECT_ID)
 }

--- a/sbercloud/cce/resource_sbercloud_cce_cluster_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_cluster_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/clusters"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -19,9 +20,9 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 	resourceName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_basic(rName),
@@ -57,9 +58,9 @@ func TestAccCCEClusterV3_withEip(t *testing.T) {
 	resourceName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_withEip(rName),
@@ -87,15 +88,15 @@ func TestAccCCEClusterV3_withEpsId(t *testing.T) {
 	resourceName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_withEpsId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", SBC_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.SBC_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -103,10 +104,10 @@ func TestAccCCEClusterV3_withEpsId(t *testing.T) {
 }
 
 func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -134,10 +135,10 @@ func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resour
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+			return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 		}
 
 		found, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
@@ -246,5 +247,5 @@ resource "sbercloud_cce_cluster" "test" {
   enterprise_project_id  = "%s"
 }
 
-`, testAccCCEClusterV3_Base(rName), rName, SBC_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccCCEClusterV3_Base(rName), rName, acceptance.SBC_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/sbercloud/cce/resource_sbercloud_cce_namespace_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_namespace_test.go
@@ -1,0 +1,138 @@
+package cce
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v1/namespaces"
+)
+
+func getNamespaceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CceV1Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SberCloud CCE v1 client: %s", err)
+	}
+	resp, err := namespaces.Get(c, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["name"]).Extract()
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("Unable to find the namespace (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccCCENamespaceV1_basic(t *testing.T) {
+	var namespace namespaces.Namespace
+	resourceName := "sbercloud_cce_namespace.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&namespace,
+		getNamespaceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENamespaceV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${sbercloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENamespaceImportStateIdFunc(randName),
+			},
+		},
+	})
+}
+
+func TestAccCCENamespaceV1_generateName(t *testing.T) {
+	var namespace namespaces.Namespace
+	resourceName := "sbercloud_cce_namespace.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&namespace,
+		getNamespaceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENamespaceV1_generateName(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${sbercloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "prefix", randName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf(`^%s[a-z0-9-]*`, randName))),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCENamespaceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "sbercloud_cce_cluster" {
+				clusterID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || name == "" {
+			return "", fmtp.Errorf("resource not found: %s/%s", clusterID, name)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, name), nil
+
+	}
+}
+
+func testAccCCENamespaceV1_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_namespace" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  name       = "%s"
+}
+`, testAccCceCluster_config(rName), rName)
+}
+
+func testAccCCENamespaceV1_generateName(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_namespace" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  prefix     = "%s"
+}
+`, testAccCceCluster_config(rName), rName)
+}

--- a/sbercloud/cce/resource_sbercloud_cce_node_attach_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_node_attach_test.go
@@ -1,0 +1,148 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func TestAccCCENodeAttachV3_basic(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "sbercloud_cce_node_attach.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "sbercloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeAttachV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "os", "CentOS 7.6"),
+				),
+			},
+			{
+				Config: testAccCCENodeAttachV3_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "os", "CentOS 7.6"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCENodeAttachV3_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_availability_zones" "test" {}
+
+data "sbercloud_images_image" "test" {
+  name = "CentOS 7.6 64bit"
+  most_recent = true
+}
+
+data "sbercloud_compute_flavors" "test" {
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "sbercloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "sbercloud_compute_instance" "test" {
+  name                        = "%s"
+  image_id                    = data.sbercloud_images_image.test.id
+  flavor_id                   = data.sbercloud_compute_flavors.test.ids[0]
+  availability_zone           = data.sbercloud_availability_zones.test.names[0]
+  key_pair                    = sbercloud_compute_keypair.test.name
+  delete_disks_on_termination = true
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+	type = "SAS"
+	size = "100"
+  }
+
+  network {
+	uuid = sbercloud_vpc_subnet.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      image_id, tags, name
+    ]
+  }
+}
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName, rName, rName)
+}
+
+func testAccCCENodeAttachV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node_attach" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  server_id  = sbercloud_compute_instance.test.id
+  key_pair   = sbercloud_compute_keypair.test.name
+  os         = "CentOS 7.6"
+  name       = "%s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCCENodeAttachV3_Base(rName), rName)
+}
+
+func testAccCCENodeAttachV3_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_node_attach" "test" {
+  cluster_id = sbercloud_cce_cluster.test.id
+  server_id  = sbercloud_compute_instance.test.id
+  key_pair   = sbercloud_compute_keypair.test.name
+  os         = "CentOS 7.6"
+  name       = "%s"
+
+  tags = {
+    foo        = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, testAccCCENodeAttachV3_Base(rName), rNameUpdate)
+}

--- a/sbercloud/cce/resource_sbercloud_cce_node_pool_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_node_pool_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodepools"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -22,9 +23,9 @@ func TestAccCCENodePool_basic(t *testing.T) {
 	clusterName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePool_basic(rName),
@@ -74,9 +75,9 @@ func TestAccCCENodePool_tags(t *testing.T) {
 	clusterName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePool_tags(rName),
@@ -101,8 +102,8 @@ func TestAccCCENodePool_tags(t *testing.T) {
 }
 
 func testAccCheckCCENodePoolDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 	}
@@ -167,8 +168,8 @@ func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools
 			return fmt.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 		}
@@ -217,7 +218,7 @@ func testAccCCENodePool_basic(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "EulerOS 2.5"
+  os                       = "Ubuntu 18.04"
   flavor_id                = "s6.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
@@ -248,7 +249,7 @@ func testAccCCENodePool_update(rName, updateName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "EulerOS 2.5"
+  os                       = "Ubuntu 18.04"
   flavor_id                = "s6.large.2"
   initial_node_count       = 2
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
@@ -279,7 +280,7 @@ func testAccCCENodePool_volume_extendParams(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "EulerOS 2.5"
+  os                       = "Ubuntu 18.04"
   flavor_id                = "s6.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
@@ -325,7 +326,7 @@ func testAccCCENodePool_tags(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "EulerOS 2.5"
+  os                       = "Ubuntu 18.04"
   flavor_id                = "s6.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
@@ -361,7 +362,7 @@ func testAccCCENodePool_tags_update(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "EulerOS 2.5"
+  os                       = "Ubuntu 18.04"
   flavor_id                = "s6.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]

--- a/sbercloud/cce/resource_sbercloud_cce_node_pool_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_node_pool_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodepools"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccCCENodePool_basic(t *testing.T) {
@@ -32,6 +33,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "current_node_count", "1"),
 				),
 			},
 			{
@@ -39,12 +41,15 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCENodePoolImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"initial_node_count",
+				},
 			},
 			{
 				Config: testAccCCENodePool_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "current_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),
@@ -66,7 +71,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 	})
 }
 
-func TestAccCCENodePool_tags(t *testing.T) {
+func TestAccCCENodePool_tagsLabelsTaints(t *testing.T) {
 	var nodePool nodepools.NodePool
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -80,21 +85,34 @@ func TestAccCCENodePool_tags(t *testing.T) {
 		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodePool_tags(rName),
+				Config: testAccCCENodePool_tagsLabelsTaints(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.test2", "val2"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test2", "val2"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
 				),
 			},
 			{
-				Config: testAccCCENodePool_tags_update(rName),
+				Config: testAccCCENodePool_tagsLabelsTaints_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.test2_update", "val2_update"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1_update"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test2_update", "val2_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.key", "test_key_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.value", "test_value_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.effect", "NoSchedule"),
 				),
 			},
 		},
@@ -105,7 +123,7 @@ func testAccCheckCCENodePoolDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
+		return fmtp.Errorf("Error creating SberCloud CCE client: %s", err)
 	}
 
 	var clusterId string
@@ -126,7 +144,7 @@ func testAccCheckCCENodePoolDestroy(s *terraform.State) error {
 
 		_, err := nodepools.Get(cceClient, clusterId, nodepollId).Extract()
 		if err == nil {
-			return fmt.Errorf("Node still exists")
+			return fmtp.Errorf("Node still exists")
 		}
 	}
 
@@ -137,14 +155,14 @@ func testAccCCENodePoolImportStateIdFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		cluster, ok := s.RootModule().Resources["sbercloud_cce_cluster.test"]
 		if !ok {
-			return "", fmt.Errorf("Cluster not found: %s", cluster)
+			return "", fmtp.Errorf("Cluster not found: %s", cluster)
 		}
 		nodePool, ok := s.RootModule().Resources["sbercloud_cce_node_pool.test"]
 		if !ok {
-			return "", fmt.Errorf("Node pool not found: %s", nodePool)
+			return "", fmtp.Errorf("Node pool not found: %s", nodePool)
 		}
 		if cluster.Primary.ID == "" || nodePool.Primary.ID == "" {
-			return "", fmt.Errorf("resource not found: %s/%s", cluster.Primary.ID, nodePool.Primary.ID)
+			return "", fmtp.Errorf("resource not found: %s/%s", cluster.Primary.ID, nodePool.Primary.ID)
 		}
 		return fmt.Sprintf("%s/%s", cluster.Primary.ID, nodePool.Primary.ID), nil
 	}
@@ -154,18 +172,18 @@ func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmtp.Errorf("Not found: %s", n)
 		}
 		c, ok := s.RootModule().Resources[cluster]
 		if !ok {
-			return fmt.Errorf("Cluster not found: %s", c)
+			return fmtp.Errorf("Cluster not found: %s", c)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmtp.Errorf("No ID is set")
 		}
 		if c.Primary.ID == "" {
-			return fmt.Errorf("Cluster id is not set")
+			return fmtp.Errorf("Cluster id is not set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
@@ -180,7 +198,7 @@ func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools
 		}
 
 		if found.Metadata.Id != rs.Primary.ID {
-			return fmt.Errorf("Node Pool not found")
+			return fmtp.Errorf("Node Pool not found")
 		}
 
 		*nodePool = *found
@@ -218,8 +236,8 @@ func testAccCCENodePool_basic(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "Ubuntu 18.04"
-  flavor_id                = "s6.large.2"
+  os                       = "CentOS 7.6"
+  flavor_id                = "c6nl.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
   key_pair                 = sbercloud_compute_keypair.test.name
@@ -249,8 +267,8 @@ func testAccCCENodePool_update(rName, updateName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "Ubuntu 18.04"
-  flavor_id                = "s6.large.2"
+  os                       = "CentOS 7.6"
+  flavor_id                = "c6nl.large.2"
   initial_node_count       = 2
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
   key_pair                 = sbercloud_compute_keypair.test.name
@@ -280,8 +298,8 @@ func testAccCCENodePool_volume_extendParams(rName string) string {
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "Ubuntu 18.04"
-  flavor_id                = "s6.large.2"
+  os                       = "CentOS 7.6"
+  flavor_id                = "c6nl.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
   key_pair                 = sbercloud_compute_keypair.test.name
@@ -319,15 +337,15 @@ resource "sbercloud_cce_node_pool" "test" {
 `, testAccCCENodePool_Base(rName), rName)
 }
 
-func testAccCCENodePool_tags(rName string) string {
+func testAccCCENodePool_tagsLabelsTaints(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "Ubuntu 18.04"
-  flavor_id                = "s6.large.2"
+  os                       = "CentOS 7.6"
+  flavor_id                = "c6nl.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
   key_pair                 = sbercloud_compute_keypair.test.name
@@ -351,19 +369,31 @@ resource "sbercloud_cce_node_pool" "test" {
 	test1 = "val1"
 	test2 = "val2"
   }
+
+  labels = {
+	test1 = "val1"
+	test2 = "val2"
+  }
+
+  taints {
+	key    = "test_key"
+	value  = "test_value"
+	effect = "NoSchedule"
+  }
+
 }
 `, testAccCCENodePool_Base(rName), rName)
 }
 
-func testAccCCENodePool_tags_update(rName string) string {
+func testAccCCENodePool_tagsLabelsTaints_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "sbercloud_cce_node_pool" "test" {
   cluster_id               = sbercloud_cce_cluster.test.id
   name                     = "%s"
-  os                       = "Ubuntu 18.04"
-  flavor_id                = "s6.large.2"
+  os                       = "CentOS 7.6"
+  flavor_id                = "c6nl.large.2"
   initial_node_count       = 1
   availability_zone        = data.sbercloud_availability_zones.test.names[0]
   key_pair                 = sbercloud_compute_keypair.test.name
@@ -386,6 +416,23 @@ resource "sbercloud_cce_node_pool" "test" {
   tags = {
 	test1        = "val1_update"
 	test2_update = "val2_update"
+  }
+
+  labels = {
+	test1        = "val1_update"
+	test2_update = "val2_update"
+  }
+
+  taints {
+	key    = "test_key"
+	value  = "test_value_update"
+	effect = "NoSchedule"
+  }
+
+  taints {
+	key    = "test_key_update"
+	value  = "test_value_update"
+	effect = "NoSchedule"
   }
 }
 `, testAccCCENodePool_Base(rName), rName)

--- a/sbercloud/cce/resource_sbercloud_cce_node_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_node_test.go
@@ -1,4 +1,4 @@
-package sbercloud
+package cce
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -23,9 +24,9 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 	clusterName := "sbercloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_basic(rName),
@@ -62,10 +63,10 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 }
 
 func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 	}
 
 	var clusterId string
@@ -106,10 +107,10 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 			return fmt.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(SBC_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.SBC_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+			return fmt.Errorf("Error creating SberCloud CCE client: %s", err)
 		}
 
 		found, err := nodes.Get(cceClient, c.Primary.ID, rs.Primary.ID).Extract()
@@ -159,6 +160,7 @@ resource "sbercloud_cce_node" "test" {
   flavor_id         = "s6.small.1"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
+  os                = "Ubuntu 18.04"
 
   root_volume {
     size       = 40
@@ -186,6 +188,7 @@ resource "sbercloud_cce_node" "test" {
   flavor_id         = "s6.small.1"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
+  os                = "Ubuntu 18.04"
 
   root_volume {
     size       = 40
@@ -213,6 +216,7 @@ resource "sbercloud_cce_node" "test" {
   flavor_id         = "s6.small.1"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
+  os                = "Ubuntu 18.04"
 
   root_volume {
     size       = 40
@@ -254,6 +258,7 @@ resource "sbercloud_cce_node" "test" {
   flavor_id         = "s6.small.1"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
+  os                = "Ubuntu 18.04"
 
   root_volume {
     size       = 40

--- a/sbercloud/cce/resource_sbercloud_cce_node_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_node_test.go
@@ -157,18 +157,18 @@ func testAccCCENodeV3_basic(rName string) string {
 resource "sbercloud_cce_node" "test" {
   cluster_id        = sbercloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "c6nl.large.2"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
-  os                = "Ubuntu 18.04"
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
   tags = {
     foo = "bar"
@@ -185,18 +185,18 @@ func testAccCCENodeV3_update(rName, updateName string) string {
 resource "sbercloud_cce_node" "test" {
   cluster_id        = sbercloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "c6nl.large.2"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
-  os                = "Ubuntu 18.04"
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
   tags = {
     foo = "bar"
@@ -213,18 +213,18 @@ func testAccCCENodeV3_auto_assign_eip(rName string) string {
 resource "sbercloud_cce_node" "test" {
   cluster_id        = sbercloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "c6nl.large.2"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
-  os                = "Ubuntu 18.04"
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
 
   // Assign EIP
@@ -255,18 +255,18 @@ resource "sbercloud_vpc_eip" "test" {
 resource "sbercloud_cce_node" "test" {
   cluster_id        = sbercloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "c6nl.large.2"
   availability_zone = data.sbercloud_availability_zones.test.names[0]
   key_pair          = sbercloud_compute_keypair.test.name
-  os                = "Ubuntu 18.04"
+  os                = "CentOS 7.6"
 
   root_volume {
-    size       = 40
-    volumetype = "SSD"
+    size       = 50
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SSD"
+    volumetype = "SAS"
   }
 
   // Assign existing EIP

--- a/sbercloud/cce/resource_sbercloud_cce_pvc_test.go
+++ b/sbercloud/cce/resource_sbercloud_cce_pvc_test.go
@@ -1,0 +1,257 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v1/persistentvolumeclaims"
+)
+
+func getPvcResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CceV1Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SberCloud CCE v1 client: %s", err)
+	}
+	resp, err := cce.GetCcePvcInfoById(c, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["namespace"], state.Primary.ID)
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("Unable to find the persistent volume claim (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccCCEPersistentVolumeClaimsV1_basic(t *testing.T) {
+	var pvc persistentvolumeclaims.PersistentVolumeClaim
+	resourceName := "sbercloud_cce_pvc.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pvc,
+		getPvcResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcePersistentVolumeClaimsV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${sbercloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class_name", "csi-disk"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCEPVCImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"annotations",
+				},
+			},
+		},
+	})
+}
+
+func TestAccCCEPersistentVolumeClaimsV1_obs(t *testing.T) {
+	var pvc persistentvolumeclaims.PersistentVolumeClaim
+	resourceName := "sbercloud_cce_pvc.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pvc,
+		getPvcResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcePersistentVolumeClaimsV1_obs(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${sbercloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class_name", "csi-obs"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCCEPersistentVolumeClaimsV1_sfs(t *testing.T) {
+	var pvc persistentvolumeclaims.PersistentVolumeClaim
+	resourceName := "sbercloud_cce_pvc.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pvc,
+		getPvcResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcePersistentVolumeClaimsV1_sfs(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${sbercloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class_name", "csi-nas"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEPVCImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		cluster, ok := s.RootModule().Resources["sbercloud_cce_cluster.test"]
+		if !ok {
+			return "", fmt.Errorf("Cluster not found: %s", cluster)
+		}
+		pvc, ok := s.RootModule().Resources["sbercloud_cce_pvc.test"]
+		if !ok {
+			return "", fmt.Errorf("PVC not found: %s", pvc)
+		}
+		if cluster.Primary.ID == "" || pvc.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", cluster.Primary.ID, pvc.Primary.ID)
+		}
+		return fmt.Sprintf("%s/default/%s", cluster.Primary.ID, pvc.Primary.ID), nil
+	}
+}
+
+func testAccCceCluster_config(rName string) string {
+	return fmt.Sprintf(`
+data "sbercloud_availability_zones" "test" {}
+
+resource "sbercloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "sbercloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.13.59"
+  secondary_dns = "8.8.8.8"
+  vpc_id        = sbercloud_vpc.test.id
+}
+
+resource "sbercloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "sbercloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = sbercloud_vpc.test.id
+  subnet_id              = sbercloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+
+resource "sbercloud_cce_node" "test" {
+  cluster_id        = sbercloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "c6nl.large.2"
+  availability_zone = data.sbercloud_availability_zones.test.names[0]
+  key_pair          = sbercloud_compute_keypair.test.name
+  os                = "CentOS 7.6"
+
+  root_volume {
+    size       = 50
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}`, rName, rName, rName, rName, rName)
+}
+
+func testAccCcePersistentVolumeClaimsV1_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = sbercloud_cce_cluster.test.id
+  namespace   = "default"
+  name        = "%s"
+  annotations = {
+    "everest.io/disk-volume-type" = "SSD"
+  }
+  storage_class_name = "csi-disk"
+  access_modes = ["ReadWriteOnce"]
+  storage = "10Gi"
+}
+`, testAccCceCluster_config(rName), rName)
+}
+
+func testAccCcePersistentVolumeClaimsV1_obs(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = sbercloud_cce_cluster.test.id
+  namespace   = "default"
+  name        = "%s"
+  annotations = {
+    "everest.io/obs-volume-type" = "STANDARD"
+    "csi.storage.k8s.io/fstype" =  "obsfs"
+  }
+  storage_class_name = "csi-obs"
+  access_modes = ["ReadWriteMany"]
+  storage = "1Gi"
+}
+`, testAccCceCluster_config(rName), rName)
+}
+
+func testAccCcePersistentVolumeClaimsV1_sfs(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sbercloud_cce_pvc" "test" {
+  cluster_id  = sbercloud_cce_cluster.test.id
+  namespace   = "default"
+  name        = "%s"
+  storage_class_name = "csi-nas"
+  access_modes = ["ReadWriteMany"]
+  storage = "10Gi"
+}
+`, testAccCceCluster_config(rName), rName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/css"
@@ -143,7 +144,9 @@ func Provider() *schema.Provider {
 			"sbercloud_cbr_vaults":             cbr.DataSourceCbrVaultsV3(),
 			"sbercloud_cce_addon_template":     huaweicloud.DataSourceCCEAddonTemplateV3(),
 			"sbercloud_cce_cluster":            huaweicloud.DataSourceCCEClusterV3(),
+			"sbercloud_cce_clusters":           cce.DataSourceCCEClusters(),
 			"sbercloud_cce_node":               huaweicloud.DataSourceCCENodeV3(),
+			"sbercloud_cce_nodes":              cce.DataSourceCCENodes(),
 			"sbercloud_cce_node_pool":          huaweicloud.DataSourceCCENodePoolV3(),
 			"sbercloud_cdm_flavors":            huaweicloud.DataSourceCdmFlavorV1(),
 			"sbercloud_compute_flavors":        huaweicloud.DataSourceEcsFlavors(),
@@ -193,8 +196,11 @@ func Provider() *schema.Provider {
 			"sbercloud_css_cluster":                     css.ResourceCssCluster(),
 			"sbercloud_cce_addon":                       huaweicloud.ResourceCCEAddonV3(),
 			"sbercloud_cce_cluster":                     huaweicloud.ResourceCCEClusterV3(),
+			"sbercloud_cce_namespace":                   cce.ResourceCCENamespaceV1(),
 			"sbercloud_cce_node":                        huaweicloud.ResourceCCENodeV3(),
+			"sbercloud_cce_node_attach":                 huaweicloud.ResourceCCENodeAttachV3(),
 			"sbercloud_cce_node_pool":                   huaweicloud.ResourceCCENodePool(),
+			"sbercloud_cce_pvc":                         cce.ResourceCcePersistentVolumeClaimsV1(),
 			"sbercloud_cdm_cluster":                     cdm.ResourceCdmCluster(),
 			"sbercloud_compute_instance":                ResourceComputeInstanceV2(),
 			"sbercloud_compute_interface_attach":        huaweicloud.ResourceComputeInterfaceAttachV2(),


### PR DESCRIPTION
This PR adds 5 objects:

**Data Sources**
sbercloud_cce_clusters
sbercloud_cce_nodes

**Resources**
sbercloud_cce_node_attach
sbercloud_cce_namespace
sbercloud_cce_pvc

Also this PR:
- Replaces all existing CCE tests to the separate directory
- Updates CCE docs

This closes #155

All CCE acceptance tests are done well:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/cce -v -run TestAccCCE -timeout 360m -parallel=1
=== RUN   TestAccCCEAddonTemplateV3DataSource_basic
=== PAUSE TestAccCCEAddonTemplateV3DataSource_basic
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== RUN   TestAccCCEClustersDataSource_basic
=== PAUSE TestAccCCEClustersDataSource_basic
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== RUN   TestAccCCENodesDataSource_basic
=== PAUSE TestAccCCENodesDataSource_basic
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== RUN   TestAccCCEAddonV3_values
=== PAUSE TestAccCCEAddonV3_values
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== RUN   TestAccCCEClusterV3_withEip
=== PAUSE TestAccCCEClusterV3_withEip
=== RUN   TestAccCCEClusterV3_withEpsId
=== PAUSE TestAccCCEClusterV3_withEpsId
=== RUN   TestAccCCENamespaceV1_basic
=== PAUSE TestAccCCENamespaceV1_basic
=== RUN   TestAccCCENamespaceV1_generateName
=== PAUSE TestAccCCENamespaceV1_generateName
=== RUN   TestAccCCENodeAttachV3_basic
=== PAUSE TestAccCCENodeAttachV3_basic
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== RUN   TestAccCCENodePool_tagsLabelsTaints
=== PAUSE TestAccCCENodePool_tagsLabelsTaints
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== RUN   TestAccCCEPersistentVolumeClaimsV1_basic
=== PAUSE TestAccCCEPersistentVolumeClaimsV1_basic
=== RUN   TestAccCCEPersistentVolumeClaimsV1_obs
=== PAUSE TestAccCCEPersistentVolumeClaimsV1_obs
=== RUN   TestAccCCEPersistentVolumeClaimsV1_sfs
=== PAUSE TestAccCCEPersistentVolumeClaimsV1_sfs
=== CONT  TestAccCCEAddonTemplateV3DataSource_basic
--- PASS: TestAccCCEAddonTemplateV3DataSource_basic (385.45s)
=== CONT  TestAccCCEClusterV3_withEpsId
--- PASS: TestAccCCEClusterV3_withEpsId (404.54s)
=== CONT  TestAccCCEPersistentVolumeClaimsV1_sfs
--- PASS: TestAccCCEPersistentVolumeClaimsV1_sfs (1014.34s)
=== CONT  TestAccCCEPersistentVolumeClaimsV1_obs
--- PASS: TestAccCCEPersistentVolumeClaimsV1_obs (691.46s)
=== CONT  TestAccCCEPersistentVolumeClaimsV1_basic
--- PASS: TestAccCCEPersistentVolumeClaimsV1_basic (686.88s)
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1317.16s)
=== CONT  TestAccCCENodePool_tagsLabelsTaints
--- PASS: TestAccCCENodePool_tagsLabelsTaints (742.46s)
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1036.86s)
=== CONT  TestAccCCENodeAttachV3_basic
--- PASS: TestAccCCENodeAttachV3_basic (770.90s)
=== CONT  TestAccCCENamespaceV1_generateName
--- PASS: TestAccCCENamespaceV1_generateName (659.95s)
=== CONT  TestAccCCENamespaceV1_basic
--- PASS: TestAccCCENamespaceV1_basic (722.33s)
=== CONT  TestAccCCENodesDataSource_basic
--- PASS: TestAccCCENodesDataSource_basic (695.69s)
=== CONT  TestAccCCEClusterV3_withEip
--- PASS: TestAccCCEClusterV3_withEip (364.80s)
=== CONT  TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (737.75s)
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (634.51s)
=== CONT  TestAccCCENodeV3DataSource_basic
--- PASS: TestAccCCENodeV3DataSource_basic (615.41s)
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (391.50s)
=== CONT  TestAccCCEClustersDataSource_basic
--- PASS: TestAccCCEClustersDataSource_basic (715.35s)
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (404.73s)
=== CONT  TestAccCCEAddonV3_values
--- PASS: TestAccCCEAddonV3_values (705.74s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/cce       13698.227s
```

