### PR TITLE
feat(AOM): add service discovery rule resource

### DIFF
--- a/docs/resources/aom_service_discovery_rule.md
+++ b/docs/resources/aom_service_discovery_rule.md
@@ -1,0 +1,147 @@
+---
+subcategory: "Application Operations Management (AOM)"
+---
+
+# sbercloud_aom_service_discovery_rule
+
+Manages an AOM service discovery rule resource within SberCloud.
+
+## Example Usage
+
+### Basic example
+
+```hcl
+resource "sbercloud_aom_service_discovery_rule" "discovery_rule" {
+  name                   = "test-rule"
+  priority               = 9999
+  detect_log_enabled     = "true"
+  discovery_rule_enabled = "true"
+  is_default_rule        = "false"
+  log_file_suffix        = ["log"]
+  service_type           = "Java"
+
+  discovery_rules {
+    check_content = ["java"]
+    check_mode    = "contain"
+    check_type    = "cmdLine"
+  }
+
+  log_path_rules {
+    name_type = "cmdLineHash"
+    args      = ["java"]
+    value     = ["/tmp/log"]
+  }
+
+  name_rules {
+    service_name_rule {
+      name_type = "str"
+      args      = ["java"]
+    }
+    application_name_rule {
+      name_type = "str"
+      args      = ["java"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the service discovery rule resource. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the rule name, which contains 4 to 63 characters. It must start
+  with a lowercase letter but cannot end with a hyphen (-). Only digits, lowercase letters, and hyphens are allowed.
+
+* `service_type` - (Required, String) Specifies the service type, which is used only for rule classification and UI display.
+  You can enter any field. For example, enter Java or Python by technology stack, or enter collector or database by function.
+
+* `discovery_rules` - (Required, List) Specifies the discovery rule. If the array contains multiple conditions, only the
+  processes that meet all the conditions will be matched. If the value of `check_type` is **cmdLine**, set the value of
+  `check_mode` to **contain**. `check_content` is in the format of ["xxx"], indicating that the process must contain
+  the xxx parameter. If the value of `check_type` is **env**, set the value of `check_mode` to **contain**.
+  `check_content` is in the format of ["k1","v1"], indicating that the process must contain the environment variable
+  whose name is k1 and value is v1. If the value of `check_type` is **scope**, set the value of `check_mode`
+  to **equals**. `check_content` is in the format of ["hostId1","hostId2"], indicating that the rule takes effect only
+  on specified nodes. If no nodes are specified, the rule applies to all nodes of the project.
+  + `check_type` - (Required, String) Specifies the match type. The values can be **cmdLine**, **env** and **scope**.
+  + `check_mode` - (Required, String) Specifies the match condition. The values can be **contain** and **equals**.
+  + `check_content` - (Required, List) Specifies the matched value. This is a list of strings.
+
+* `name_rules` - (Required, List) Specifies the naming rules for discovered services and applications.
+  The [object](#name_rules_object) structure is documented below.
+
+* `log_file_suffix` - (Required, List) Specifies the log file suffix. This is a list of strings.
+  The values can be: **log**, **trace**, and **out**.
+
+* `detect_log_enabled` - (Optional, Bool) Specifies whether to enable log collection. The default value is true.
+
+* `priority` - (Optional, Int) Specifies the rule priority. Value range: 1 to 9999. The default value is 9999.
+
+* `discovery_rule_enabled` - (Optional, Bool) Specifies whether the rule is enabled. The default value is true.
+
+* `is_default_rule` - (Optional, Bool) Specifies whether the rule is the default one. The default value is false.
+
+* `log_path_rules` - (Optional, List) Specifies the log path configuration rule. If cmdLineHash is a fixed string,
+  logs in the specified log path or log file are collected. Otherwise, only the files whose names end with
+  .log or .trace are collected. If the value of `name_type` is **cmdLineHash**, args is in the format of ["00001"] and
+  value is in the format of ["/xxx/xx.log"], indicating that the log path is /xxx/xx.log when the startup command is 00001.
+  + `name_type` - (Required, String) Specifies the value type, which can be **cmdLineHash**.
+  + `args` - (Required, List) Specifies the command. This is a list of strings.
+  + `value` - (Required, List) Specifies the log path. This is a list of strings.
+
+<a name="name_rules_object"></a>
+The `name_rules` block supports:
+
+* `service_name_rule` - (Required, List) Specifies the service name rule. If there are multiple objects in the array,
+  the character strings extracted from these objects constitute the service name. If the value of `name_type` is
+  **cmdLine**, `args` is in the format of ["start", "end"], indicating that the characters between start and end
+  in the command are extracted. If the value of `name_type` is **env**, `args` is in the format of ["aa"],
+  indicating that the environment variable named aa is extracted. If the value of `name_type` is **str**, `args` is in the
+  format of ["fix"], indicating that the service name is suffixed with fix. If the value of `name_type` is
+  **cmdLineHash**, `args` is in the format of ["0001"] and `value` is in the format of ["ser"], indicating that the
+  service name is ser when the startup command is 0001. The [object](#basic_name_rule_object) structure is
+  documented below.
+
+* `application_name_rule` - (Required, List) Specifies the application name rule. If the value of `name_type` is
+  **cmdLine**, `args` is in the format of ["start", "end"], indicating that the characters between start and end in
+  the command are extracted. If the value of `name_type` is **env**, `args` is in the format of ["aa"], indicating that
+  the environment variable named aa is extracted. If the value of `name_type` is **str**, `args` is in the format of
+  ["fix"], indicating that the application name is suffixed with fix. If the value of `name_type` is **cmdLineHash**,
+  `args` is in the format of ["0001"] and `value` is in the format of ["ser"], indicating that the application name is
+  ser when the startup command is 0001. The [object](#basic_name_rule_object) structure is documented below.
+
+<a name="basic_name_rule_object"></a>
+The `service_name_rule` block and `application_name_rule` block support:
+
+* `name_type` - (Required, String) Specifies the value type. The value can be **cmdLineHash**, **cmdLine**, **env**
+and **str**.
+* `args` - (Required, List) Specifies the input value.
+* `value` - (Optional, List) Specifies the application name, which is mandatory only when the value of
+`name_type` is **cmdLineHash**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the resource ID of the service discovery rule. The value is the rule name.
+
+* `rule_id` - The rule ID in uuid format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+AOM service discovery rules can be imported using the `name`, e.g.
+
+```
+$ terraform import sbercloud_aom_service_discovery_rule.alarm_rule rule_name
+```

--- a/sbercloud/aom/resource_sbercloud_aom_service_discovery_rule_test.go
+++ b/sbercloud/aom/resource_sbercloud_aom_service_discovery_rule_test.go
@@ -1,0 +1,169 @@
+package aom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	aomservice "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	aom "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/aom/v2/model"
+)
+
+func getServiceDiscoveryRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.HcAomV2Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM client: %s", err)
+	}
+
+	response, err := c.ListServiceDiscoveryRules(&aom.ListServiceDiscoveryRulesRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AOM service discovery rule: %s", state.Primary.ID)
+	}
+
+	allRules := *response.AppRules
+
+	return aomservice.FilterRules(allRules, state.Primary.ID)
+}
+
+func TestAccAOMServiceDiscoveryRule_basic(t *testing.T) {
+	var ar aom.QueryAlarmResult
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := rName + "-update"
+	resourceName := "sbercloud_aom_service_discovery_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&ar,
+		getServiceDiscoveryRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMServiceDiscoveryRule_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "priority", "9999"),
+					resource.TestCheckResourceAttr(resourceName, "detect_log_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "discovery_rule_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_default_rule", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_file_suffix.0", "log"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "Python"),
+					resource.TestCheckResourceAttr(resourceName, "discovery_rules.0.check_content.0", "python"),
+					resource.TestCheckResourceAttr(resourceName, "log_path_rules.0.args.0", "python"),
+					resource.TestCheckResourceAttr(
+						resourceName, "name_rules.0.service_name_rule.0.args.0", "python"),
+					resource.TestCheckResourceAttr(
+						resourceName, "name_rules.0.application_name_rule.0.args.0", "python"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAOMServiceDiscoveryRule_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "priority", "9998"),
+					resource.TestCheckResourceAttr(resourceName, "detect_log_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "discovery_rule_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "is_default_rule", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_file_suffix.0", "trace"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "Java"),
+					resource.TestCheckResourceAttr(resourceName, "discovery_rules.0.check_content.0", "java"),
+					resource.TestCheckResourceAttr(resourceName, "log_path_rules.0.args.0", "java"),
+					resource.TestCheckResourceAttr(
+						resourceName, "name_rules.0.service_name_rule.0.args.0", "java"),
+					resource.TestCheckResourceAttr(
+						resourceName, "name_rules.0.application_name_rule.0.args.0", "java"),
+				),
+			},
+		},
+	})
+}
+
+func testAOMServiceDiscoveryRule_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_aom_service_discovery_rule" "test" {
+  name                   = "%s"
+  priority               = 9999
+  detect_log_enabled     = true
+  discovery_rule_enabled = true
+  is_default_rule        = true
+  log_file_suffix        = ["log"]
+  service_type           = "Python"
+
+  discovery_rules {
+    check_content = ["python"]
+    check_mode    = "contain"
+    check_type    = "cmdLine"
+  }
+
+  log_path_rules {
+    name_type = "cmdLineHash"
+    args      = ["python"]
+    value     = ["/tmp/log"]
+  }
+
+  name_rules {
+    service_name_rule {
+      name_type = "str"
+      args      = ["python"]
+    }
+    application_name_rule {
+      name_type = "str"
+      args      = ["python"]
+    }
+  }
+}
+`, rName)
+}
+
+func testAOMServiceDiscoveryRule_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_aom_service_discovery_rule" "test" {
+  name                   = "%s"
+  priority               = 9998
+  detect_log_enabled     = false
+  discovery_rule_enabled = false
+  is_default_rule        = false
+  log_file_suffix        = ["trace"]
+  service_type           = "Java"
+
+  discovery_rules {
+    check_content = ["java"]
+    check_mode    = "contain"
+    check_type    = "cmdLine"
+  }
+
+  log_path_rules {
+    name_type = "cmdLineHash"
+    args      = ["java"]
+    value     = ["/tmp/log"]
+  }
+
+  name_rules {
+    service_name_rule {
+      name_type = "str"
+      args      = ["java"]
+    }
+    application_name_rule {
+      name_type = "str"
+      args      = ["java"]
+    }
+  }
+}
+`, rName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdm"
@@ -183,6 +184,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"sbercloud_aom_service_discovery_rule":      aom.ResourceServiceDiscoveryRule(),
 			"sbercloud_api_gateway_api":                 huaweicloud.ResourceAPIGatewayAPI(),
 			"sbercloud_api_gateway_group":               huaweicloud.ResourceAPIGatewayGroup(),
 			"sbercloud_as_configuration":                as.ResourceASConfiguration(),


### PR DESCRIPTION
This PR adds `sbercloud_aom_service_discovery_rule` resource

Related to #151

All related acceptance tests are done well:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./sbercloud/aom -v  -timeout 360m -parallel=1
=== RUN   TestAccAOMServiceDiscoveryRule_basic
=== PAUSE TestAccAOMServiceDiscoveryRule_basic
=== CONT  TestAccAOMServiceDiscoveryRule_basic
--- PASS: TestAccAOMServiceDiscoveryRule_basic (23.58s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/aom       24.146s
```