### PR TITLE
Update nat deprecated keys

### DIFF
--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -13,8 +13,8 @@ resource "sbercloud_nat_gateway" "nat_1" {
   name                = "Terraform"
   description         = "test for terraform"
   spec                = "3"
-  router_id           = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
-  internal_network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  vpc_id              = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+  subnet_id           = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
 }
 ```
 
@@ -29,11 +29,11 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the nat gateway name. The name can
     contain only digits, letters, underscores (_), and hyphens(-).
 
-* `internal_network_id` - (Required, String, ForceNew) Specifies the network ID
+* `subnet_id` (previously `internal_network_id`) - (Required, String, ForceNew) Specifies the network ID
     of the downstream interface (the next hop of the DVR) of the NAT gateway.
     Changing this creates a new nat gateway.
 
-* `router_id` - (Required, String, ForceNew) Specifies the ID of the router
+* `vpc_id` (previously `router_id`) - (Required, String, ForceNew) Specifies the ID of the router
     this nat gateway belongs to. Changing this creates a new nat gateway.
 
 * `spec` - (Required, String) Specifies the nat gateway type.

--- a/docs/resources/nat_snat_rule.md
+++ b/docs/resources/nat_snat_rule.md
@@ -11,7 +11,7 @@ Manages a Snat rule resource within SberCloud Nat
 ```hcl
 resource "sbercloud_nat_snat_rule" "snat_1" {
   nat_gateway_id = "3c0dffda-7c76-452b-9dcc-5bce7ae56b17"
-  network_id     = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  subnet_id      = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
   floating_ip_id = "0a166fc5-a904-42fb-b1ef-cf18afeeddca"
 }
 ```
@@ -28,7 +28,7 @@ The following arguments are supported:
 * `floating_ip_id` - (Required, String, ForceNew) ID of the floating ip this snat rule connets to.
     Changing this creates a new snat rule.
 
-* `network_id` - (Optional, String, ForceNew) ID of the network this snat rule connects to.
+* `subnet_id` (previously `network_id`) - (Optional, String, ForceNew) ID of the network this snat rule connects to.
     This parameter and `cidr` are alternative. Changing this creates a new snat rule.
 
 * `cidr` - (Optional, String, ForceNew) Specifies CIDR, which can be in the format of a network segment or a host IP address.


### PR DESCRIPTION
This pull request proposes changes to resources documentation.

Some keys in NAT resources have been changed.
In NAT Gateway:
- `router_id` → `vpc_id`,
- `internal_network_id` → `subnet_id`.

In SNAT Rule:
- `network_id` → `subnet_id`.

Old keys automatically displayed as deprecated and terraform shows warning when using them.