### PR TITLE
fix(cce): restore certificate refresh guard

### DIFF
--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -905,45 +905,48 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 		mErr = multierror.Append(mErr, d.Set("charging_mode", "prePaid"))
 	}
 
-	// duration -1 is equal to the maximum value 1827 days
-	opts := clusters.GetCertOpts{Duration: -1}
-	r := clusters.GetCert(cceClient, d.Id(), opts)
+	// The certificate endpoint issues a new client certificate on every call.
+	// Keep the certificate already stored in state during refreshes to avoid
+	// perpetual drift. Fetch it only after creation or import, when state does
+	// not contain a kubeconfig yet.
+	if _, ok := d.GetOk("kube_config_raw"); !ok {
+		// duration -1 is equal to the maximum value 1827 days
+		opts := clusters.GetCertOpts{Duration: -1}
+		r := clusters.GetCert(cceClient, d.Id(), opts)
 
-	kubeConfigRaw, err := utils.JsonMarshal(r.Body)
+		cert, err := r.Extract()
+		if err != nil {
+			return diag.Errorf("error retrieving CCE cluster certificate: %s", err)
+		}
 
-	if err != nil {
-		log.Printf("error marshaling r.Body: %s", err)
+		kubeConfigRaw, err := utils.JsonMarshal(r.Body)
+		if err != nil {
+			return diag.Errorf("error marshaling CCE cluster certificate: %s", err)
+		}
+		mErr = multierror.Append(mErr, d.Set("kube_config_raw", string(kubeConfigRaw)))
+
+		// Set Certificate Clusters
+		var clusterList []map[string]interface{}
+		for _, clusterObj := range cert.Clusters {
+			clusterCert := make(map[string]interface{})
+			clusterCert["name"] = clusterObj.Name
+			clusterCert["server"] = clusterObj.Cluster.Server
+			clusterCert["certificate_authority_data"] = clusterObj.Cluster.CertAuthorityData
+			clusterList = append(clusterList, clusterCert)
+		}
+		mErr = multierror.Append(mErr, d.Set("certificate_clusters", clusterList))
+
+		// Set Certificate Users
+		var userList []map[string]interface{}
+		for _, userObj := range cert.Users {
+			userCert := make(map[string]interface{})
+			userCert["name"] = userObj.Name
+			userCert["client_certificate_data"] = userObj.User.ClientCertData
+			userCert["client_key_data"] = userObj.User.ClientKeyData
+			userList = append(userList, userCert)
+		}
+		mErr = multierror.Append(mErr, d.Set("certificate_users", userList))
 	}
-
-	mErr = multierror.Append(mErr, d.Set("kube_config_raw", string(kubeConfigRaw)))
-
-	cert, err := r.Extract()
-
-	if err != nil {
-		log.Printf("error retrieving CCE cluster certificate: %s", err)
-	}
-
-	//Set Certificate Clusters
-	var clusterList []map[string]interface{}
-	for _, clusterObj := range cert.Clusters {
-		clusterCert := make(map[string]interface{})
-		clusterCert["name"] = clusterObj.Name
-		clusterCert["server"] = clusterObj.Cluster.Server
-		clusterCert["certificate_authority_data"] = clusterObj.Cluster.CertAuthorityData
-		clusterList = append(clusterList, clusterCert)
-	}
-	mErr = multierror.Append(mErr, d.Set("certificate_clusters", clusterList))
-
-	//Set Certificate Users
-	var userList []map[string]interface{}
-	for _, userObj := range cert.Users {
-		userCert := make(map[string]interface{})
-		userCert["name"] = userObj.Name
-		userCert["client_certificate_data"] = userObj.User.ClientCertData
-		userCert["client_key_data"] = userObj.User.ClientKeyData
-		userList = append(userList, userCert)
-	}
-	mErr = multierror.Append(mErr, d.Set("certificate_users", userList))
 
 	// Set masters
 	var masterList []map[string]interface{}


### PR DESCRIPTION
### What this PR does / why we need it:

The CCE certificate drift fix introduced in the previous PR was overwritten when the vendored HuaweiCloud provider was updated to v1.85.0.

The CCE certificate endpoint generates a new client certificate on every call. Calling it during every resource refresh causes perpetual drift in `certificate_users`.

This PR reapplies the fix on top of the current provider version. Certificate data is now requested only when `kube_config_raw` is absent, such as during cluster creation or import. Existing certificate data stored in the state is preserved during subsequent refreshes.

Related to #424

***Added objects:***

- None.

***Updated objects:***

- Restored the certificate refresh guard in `sbercloud_cce_cluster`.
- Improved error handling for CCE certificate retrieval and serialization.

### PR Checklist

- [x] Tests added/passed.
- [x] Documentation updated (not required).
- [x] Schema updated (not required).

## Acceptance Steps Performed

```shell
gofmt -d vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go

git diff --check

GOCACHE=/tmp/sbercloud-go-cache \
GOMODCACHE=/tmp/sbercloud-go-mod-cache \
go test -mod=vendor ./sbercloud -run '^$'